### PR TITLE
Don't limit the size of the glob/globSync result set by default (omit GLOB_LIMIT from GLOB_DEFAULTS)

### DIFF
--- a/lib/glob.js
+++ b/lib/glob.js
@@ -28,7 +28,6 @@ fnmatch.FNM_DEFAULT = exports.FNM_DEFAULT
 fnmatch[fnmatch.FNM_DEFAULT] = "FNM_DEFAULT"
 
 exports.GLOB_DEFAULT = binding.GLOB_BRACE
-                     | binding.GLOB_LIMIT
                      | binding.GLOB_STAR
                      | binding.GLOB_MARK
                      | binding.GLOB_TILDE


### PR DESCRIPTION
See https://github.com/isaacs/node-glob/issues/11
