### PR TITLE
Found a missing "var"

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -418,6 +418,7 @@ Glob.prototype._stat = function (f, cb) {
 }
 
 Glob.prototype._afterStat = function (f, abs, cb, er, stat) {
+  var exists;
   assert(this instanceof Glob)
   if (er || !stat) {
     exists = false


### PR DESCRIPTION
The variable "exists" in "Glob.prototype._afterStat" was leaking. My mocha-tests were complaining about it, so I fixed it to make my tests pass.
