### PR TITLE
Multi Glob patterns 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See:
 * `man 5 gitignore`
 * [minimatch documentation](https://github.com/isaacs/minimatch)
 
-## glob(pattern, [options], cb)
+## glob(pattern*, [options], cb)
 
 * `pattern` {String} Pattern to be matched
 * `options` {Object}
@@ -57,7 +57,7 @@ See:
 
 Perform an asynchronous glob search.
 
-## glob.sync(pattern, [options]
+## glob.sync(pattern*, [options]
 
 * `pattern` {String} Pattern to be matched
 * `options` {Object}
@@ -77,7 +77,7 @@ var mg = new Glob(pattern, options, cb)
 It's an EventEmitter, and starts walking the filesystem to find matches
 immediately.
 
-### new glob.Glob(pattern, [options], [cb])
+### new glob.Glob(pattern*, [options], [cb])
 
 * `pattern` {String} pattern to search for
 * `options` {Object}

--- a/glob.js
+++ b/glob.js
@@ -46,7 +46,28 @@ var fs = require("graceful-fs")
 , assert = require("assert").ok
 , EOF = {}
 
-function glob (pattern, options, cb) {
+// parse `pattern*, options, cb` into `{pattern1,pattern2,...}, options, cb`
+function parseArguments(){
+  var obj = {};
+  var patterns = Array.prototype.filter.call(arguments, function(arg){
+    return typeof arg === "string"
+  })
+
+  obj.pattern = arguments[0]
+  if(patterns.length > 1) obj.pattern = '{' + patterns.join(',') + '}'
+
+  obj.options = arguments[patterns.length]
+  obj.cb = arguments[patterns.length +1 ]
+
+  return obj
+}
+
+function glob (/* pattern*, options, cb */) {
+  var args = parseArguments.apply(this, arguments),
+    pattern = args.pattern,
+    options = args.options,
+    cb = args.cb
+
   if (typeof options === "function") cb = options, options = {}
   if (!options) options = {}
 
@@ -66,7 +87,11 @@ function deprecated () {
 }
 
 glob.sync = globSync
-function globSync (pattern, options) {
+function globSync (/* pattern*, options */) {
+  var args = parseArguments.apply(this, arguments),
+    pattern = args.pattern,
+    options = args.options
+
   if (typeof options === "number") {
     deprecated()
     return
@@ -74,16 +99,21 @@ function globSync (pattern, options) {
 
   options = options || {}
   options.sync = true
+
   return glob(pattern, options)
 }
 
 
 glob.Glob = Glob
 inherits(Glob, EE)
-function Glob (pattern, options, cb) {
+function Glob (/* pattern*, options, cb */) {
   if (!(this instanceof Glob)) {
     return new Glob(pattern, options, cb)
   }
+  var args = parseArguments.apply(this, arguments),
+    pattern = args.pattern,
+    options = args.options,
+    cb = args.cb
 
   if (typeof cb === "function") {
     this.on("error", cb)

--- a/test/multiglob-test.js
+++ b/test/multiglob-test.js
@@ -1,0 +1,31 @@
+var tap = require("tap")
+
+var origCwd = process.cwd()
+process.chdir(__dirname)
+
+tap.test("multiglob pattern for **/d", function (t) {
+  var glob = require('../')
+  var path = require('path')
+  t.test('multiglob', function (t) {
+    glob( 'a/b/*/d', 'a/c/**/d', function (er, matches) {
+      t.ifError(er)
+      t.like(matches, [ 'a/b/c/d', 'a/c/d' ])
+      t.end()
+    })
+  })
+
+  t.test('multiglob with inner brace set', function (t) {
+    glob( '{/*,*}', 'a/b/*/d', 'a/c/**/d', function (er, matches) {
+      t.ifError(er)
+      t.ok(matches.length > 10, 'inner brace set results should be present')
+      t.end()
+    })
+  })
+
+  t.test('cd -', function (t) {
+    process.chdir(origCwd)
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Hi, 

Reading the issue #36, I found that a allowing several patterns would be useful for my future applications.

Here is the pull request.It allow the following syntaxes:

```
glob("**/*.js", "**/*.coffee", options, cb)
glob.sync("**/*.js", "**/*.coffee", options)
new Glob("**/*.js", "**/*.coffee", options, cb)
```

I use the brace set to implement it :

```
glob("**/*.js", "**/*.coffee", options, cb) === glob("{**/*.js,**/*.coffee}", options, cb)
```
