### PR TITLE
fix issue #42

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -342,7 +342,7 @@ Glob.prototype._process = function (pattern, depth, index, cb_) {
   var read
   if (prefix === null) read = "."
   else if (isAbsolute(prefix)) {
-    read = prefix = path.join("/", prefix)
+    read = prefix = path.resolve("/", prefix)
     if (this.debug) console.error('absolute: ', prefix, this.root, pattern)
   } else read = prefix
 


### PR DESCRIPTION
Using resolve instead of join make it working on both linux and windows.

I've run tests on linux and everything is ok.

On windows tests crash on setup :(.
But all following cases work:

``` javascript
 glob('/test/**/*.js')
```

``` javascript
 glob('c:/test/**/*.js') 
```

``` javascript
 glob('test/**/*.js')  //assuming process.cwd is c:
```
