### PR TITLE
Fixes #51

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -357,7 +357,9 @@ Glob.prototype._process = function (pattern, depth, index, cb_) {
   var read
   if (prefix === null) read = "."
   else if (isAbsolute(prefix) || isAbsolute(pattern.join("/"))) {
-    read = prefix = path.resolve(path.join("/", prefix))
+    if (process.platform !== "win32")
+      prefix = path.join("/", prefix)
+    read = prefix = path.resolve(prefix)
 
     if (process.platform === "win32")
       read = prefix = prefix.replace(/^[a-zA-Z]:|\\/g, "/")


### PR DESCRIPTION
The culprit for #51 is dcf038edfd5ca95e634ab8a3959b5bfe24568115, specifically this line is the problem:

``` javascript
read = prefix = path.resolve(path.join("/", prefix))
```

I made a small PoC which shows the bug:

``` javascript
var path = require('path');

var prefix = "n:/dev/node-glob/asdf/yeah";

console.log("prefix: ", prefix);
console.log("path.join('/', prefix): ", path.join('/', prefix));
console.log("path.resolve(path.join('/', prefix)): ", path.resolve(path.join('/', prefix)));
console.log("path.resolve(prefix): ", path.resolve(prefix));
```

The output:

```
prefix:  n:/dev/node-glob/asdf/yeah
path.join('/', prefix):  \n:\dev\node-glob\asdf\yeah
path.resolve(path.join('/', prefix)):  n:\n:\dev\node-glob\asdf\yeah
path.resolve(prefix):  n:\dev\node-glob\asdf\yeah
```

So the problem is that you get a double `n:\` on Windows when adding a `/` before `prefix`

I made a folder with a couple of JS files and a small program that displays the result of `glob`:

``` javascript
var glob = require('./glob');

var path = "asdf/**/*.js";

glob(path, function(err, files) {
  console.log('path: ', path);
  console.log(files)
});

path = __dirname + "/asdf/**/*.js";

glob(path, function(err, files) {
  console.log('path: ', path);
  console.log(files)
});
```

The output before the fix:

``` sh
$ node test-join.js

path:  n:\dev\node-glob/asdf/**/*.js
[]

path:  n:\dev\node-glob/asdf/**/*.js
[ 'asdf/test.js', 'asdf/yeah/yeah.js' ]
```

And after the fix:

``` sh
$ node test-join.js

path:  n:\dev\node-glob/asdf/**/*.js
[ 'n:/dev/node-glob/asdf/test.js',
  'n:/dev/node-glob/asdf/yeah/yeah.js' ]

path:  n:\dev\node-glob/asdf/**/*.js
[ 'asdf/test.js', 'asdf/yeah/yeah.js' ]
```
