### PR TITLE
Remove undeclared dependency on graceful-fs

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -36,7 +36,7 @@
 
 module.exports = glob
 
-var fs = require("graceful-fs")
+var fs = require("fs")
 , minimatch = require("minimatch")
 , Minimatch = minimatch.Minimatch
 , inherits = require("inherits")


### PR DESCRIPTION
Looks like the `graceful-fs` dependency was [removed](https://github.com/isaacs/node-glob/commit/49122ad716730a7d56a03edb6a5c15225eebe3f1#package.json) but is still being required.
