### PR TITLE
Clarify that passing cb requires passing (empty) options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ var mg = new Glob(pattern, options, cb)
 It's an EventEmitter, and starts walking the filesystem to find matches
 immediately.
 
-### new glob.Glob(pattern, [options], [cb])
+### new glob.Glob(pattern, [options, [cb]])
 
 * `pattern` {String} pattern to search for
 * `options` {Object}


### PR DESCRIPTION
You cannot call `new glob.Glob(pattern, cb)`.
