### PR TITLE
remove the ^ from the minimatch depenency because it was causing a probl...

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "name": "glob",
   "description": "a little globber",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/node-glob.git"
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "inherits": "2",
-    "minimatch": "^0.3.0"
+    "minimatch": "0.3.0"
   },
   "devDependencies": {
     "tap": "~0.4.0",


### PR DESCRIPTION
...em when npm installing from windows

Its funny, the ^ in the minimatch dependency worked fine on my Mac but was causing a problem when I did an npm install in windows.

Here is a link to the issue I just reported:
https://github.com/isaacs/node-glob/issues/97

Thanks so much for looking into this!  It is causing a problem today when I tried to npm install the grunt-contrib-jshint  on my coworkers windows box.
