### PR TITLE
Fixed the version range for 'minimatch'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-{
+B1;3409;0c{
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "name": "glob",
   "description": "a little globber",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "inherits": "2",
-    "minimatch": "^0.3.0"
+    "minimatch": "~0.3.0"
   },
   "devDependencies": {
     "tap": "~0.4.0",


### PR DESCRIPTION
Trying to install appium@1.1.0 that just upgraded to glob@4.0.0 I get this error:

```
npm ERR! Error: No compatible version found: minimatch@'^0.3.0'
npm ERR! Valid install targets:
npm ERR! ["0.0.1","0.0.2","0.0.4","0.0.5","0.1.1","0.1.2","0.1.3","0.1.4","0.1.5","0.2.0","0.2.2","0.2.3","0.2.4","0.2.5","0.2.6","0.2.7","0.2.8","0.2.9","0.2.10","0.2.11","0.2.12","0.2.13","0.2.14","0.3.0"]
```
