### PR TITLE
Usage of ^ in dependencies breaks Travis CI build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "inherits": "2",
-    "minimatch": "^0.3.0"
+    "minimatch": "~0.3.0"
   },
   "devDependencies": {
     "tap": "~0.4.0",


### PR DESCRIPTION
build on node 0.8 log:

``` bash
npm http GET https://registry.npmjs.org/glob
npm http 304 https://registry.npmjs.org/glob
npm ERR! Error: No compatible version found: minimatch@'^0.3.0'
npm ERR! Valid install targets:
npm ERR! ["0.0.1","0.0.2","0.0.4","0.0.5","0.1.1","0.1.2","0.1.3","0.1.4","0.1.5","0.2.0","0.2.2","0.2.3",
"0.2.4","0.2.5","0.2.6","0.2.7","0.2.8","0.2.9","0.2.10","0.2.11","0.2.12","0.2.13","0.2.14","0.3.0"]
npm ERR!     at installTargetsError (/home/travis/.nvm/v0.8.26/lib/node_modules/npm/lib/cache.js:719:10)
npm ERR!     at /home/travis/.nvm/v0.8.26/lib/node_modules/npm/lib/cache.js:641:10
npm ERR!     at RegClient.get_ (/home/travis/.nvm/v0.8.26/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:101:14)
npm ERR!     at RegClient.<anonymous> (/home/travis/.nvm/v0.8.26/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:37:12)
npm ERR!     at fs.readFile (fs.js:176:14)
npm ERR!     at Object.oncomplete (fs.js:297:15)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
npm ERR! System Linux 2.6.32-042stab079.5
npm ERR! command "/home/travis/.nvm/v0.8.26/bin/node" "/home/travis/.nvm/v0.8.26/bin/npm" "install"
npm ERR! cwd /home/travis/build/stormpath/stormpath-sdk-node
npm ERR! node -v v0.8.26
npm ERR! npm -v 1.2.30
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/travis/build/stormpath/stormpath-sdk-node/npm-debug.log
npm ERR! not ok code 0
The command "npm install" failed and exited with 1 during .
```
