### PR TITLE
Add npm ignore file.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+test
+examples
+.travis.yml
+oh-my-glob.gif


### PR DESCRIPTION
Compared with the whole lib (50KB), the file `oh-my-glob.gif` is 500KB, and it will published with npm. Why not ignore it?
