### PR TITLE
adding configuration for bower to enable glob to be installed using bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "node-glob",
+  "version": "4.0.6",
+  "homepage": "https://github.com/isaacs/node-glob",
+  "authors": [
+    "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)"
+  ],
+  "description": "a little globber",
+  "main": "glob.js",
+  "moduleType": [
+    "node"
+  ],
+  "keywords": [
+    "glob"
+  ],
+  "license": "ISC",
+  "ignore": [
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I have added a `bower.json` to enable glob to be installed using bower (or to be a depedency of an existing bower component).  For more information on bower see: http://bower.io/.

I would be grateful if you could merge this into you project then run:

```bash
bower register glob git://github.com/isaacs/node-glob.git
```

(see: http://bower.io/docs/creating-packages/)

To confirm that glob has been install correctly you are use the following curl command:

```bash
curl http://bower.herokuapp.com/packages/glob
```

If it returns some JSON then you have registered glob with bower.

This will then register your git repository with bower and allow anyone to install glob using:

```bash
bower install glob
```

And it will allow me to have glob as a dependency in my project [mockserver-grunt](https://www.npmjs.org/package/mockserver-grunt)

Thanks,

James