### PR TITLE
Fixed accidental global var in _readdir

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -394,7 +394,7 @@ Glob.prototype._readdir = function (abs, inGlobStar, cb) {
     return this._readdirInGlobStar(abs, cb)
 
   if (ownProp(this.cache, abs)) {
-    c = this.cache[abs]
+    var c = this.cache[abs]
     if (!c || c === 'FILE')
       return cb()
 


### PR DESCRIPTION
I tried running the test suite in a module of mine after updating glob to 4.1.3, and mocha complained that `c` is leaked into the global scope. Luckily it was an easy fix.

Otherwise, everything works as expected. Great work on 4.1.x!
