### PR TITLE
New: Added ignore option (fixes #115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ filesystem.
 * `nocomment` Suppress `comment` behavior.  (See below.)
 * `nonull` Return the pattern when no matches are found.
 * `nodir` Do not match directories, only files.
+* `ignore` Add a pattern or an array of patterns to exclude matches.
 
 ## Comparisons to other fnmatch/glob implementations
 

--- a/common.js
+++ b/common.js
@@ -6,6 +6,7 @@ exports.ownProp = ownProp
 exports.makeAbs = makeAbs
 exports.finish = finish
 exports.mark = mark
+exports.isIgnored = isIgnored
 
 function ownProp (obj, field) {
   return Object.prototype.hasOwnProperty.call(obj, field)
@@ -41,6 +42,28 @@ function alphasort (a, b) {
   return a.localeCompare(b)
 }
 
+function ignoreMap (self, options) {
+  self.ignore = options.ignore || []
+
+  if (!Array.isArray(self.ignore))
+    self.ignore = [self.ignore]
+
+  if (self.ignore.length) {
+    self.ignore = self.ignore.map(function (pattern) {
+      if (pattern.indexOf('!') >= 0 )
+        throw new Error("Negations are not allowed in ignore")
+
+      var endsWithGlobStar = pattern.slice(-3) === '/**'
+      var endsWithStar = pattern.slice(-2) === '/*'
+      var m = { matcher: new Minimatch(pattern) }
+
+      if (endsWithGlobStar)
+        m.gmatcher = new Minimatch(pattern.slice(0, pattern.replace(/(\/\*\*)+$/, '').length))
+
+      return m
+    })
+  }
+}
 
 function setopts (self, pattern, options) {
   if (!options)
@@ -73,6 +96,8 @@ function setopts (self, pattern, options) {
   self.cache = options.cache || Object.create(null)
   self.statCache = options.statCache || Object.create(null)
   self.symlinks = options.symlinks || Object.create(null)
+
+  ignoreMap(self, options)
 
   self.changedCwd = false
   var cwd = process.cwd()
@@ -139,6 +164,11 @@ function finish (self) {
     }
   }
 
+  if (self.ignore.length)
+    all = all.filter(function(m) {
+      return !isIgnored(self, m)
+    })
+
   self.found = all
 }
 
@@ -166,7 +196,7 @@ function mark (self, p) {
 // lotta situps...
 function makeAbs (self, f) {
   var abs = f
-  if (f.charAt(0) === "/") {
+  if (f.charAt(0) === '/') {
     abs = path.join(self.root, f)
   } else if (exports.isAbsolute(f)) {
     abs = f
@@ -174,4 +204,21 @@ function makeAbs (self, f) {
     abs = path.resolve(self.cwd, f)
   }
   return abs
+}
+
+
+// Return true, if pattern ends with globstar '**', for the accompanying parent directory.
+// Ex:- If node_modules/** is the pattern, add 'node_modules' to ignore list along with it's contents
+function isIgnored (self, path, checktrailingStar) {
+  if (!self.ignore.length)
+    return false
+
+  if (checktrailingStar)
+    return self.ignore.some(function(item) {
+      return !!(item.gmatcher && item.gmatcher.match(path))
+    })
+  else
+    return self.ignore.some(function(item) {
+      return item.matcher.match(path) || !!(item.gmatcher && item.gmatcher.match(path))
+    })
 }

--- a/glob.js
+++ b/glob.js
@@ -56,6 +56,7 @@ var setopts = common.setopts
 var ownProp = common.ownProp
 var inflight = require('inflight')
 var util = require('util')
+var isIgnored = common.isIgnored
 
 var once = require('once')
 
@@ -270,13 +271,16 @@ Glob.prototype._process = function (pattern, index, inGlobStar, cb) {
 
   var abs = this._makeAbs(read)
 
+  //if ignored, skip _processing
+  if (isIgnored(this, read, true))
+    return cb()
+
   var isGlobStar = remain[0] === minimatch.GLOBSTAR
   if (isGlobStar)
     this._processGlobStar(prefix, read, abs, remain, index, inGlobStar, cb)
   else
     this._processReaddir(prefix, read, abs, remain, index, inGlobStar, cb)
 }
-
 
 Glob.prototype._processReaddir = function (prefix, read, abs, remain, index, inGlobStar, cb) {
   var self = this

--- a/sync.js
+++ b/sync.js
@@ -14,6 +14,7 @@ var alphasorti = common.alphasorti
 var isAbsolute = common.isAbsolute
 var setopts = common.setopts
 var ownProp = common.ownProp
+var isIgnored = common.isIgnored
 
 function globSync (pattern, options) {
   if (typeof options === 'function' || arguments.length === 3)
@@ -98,12 +99,17 @@ GlobSync.prototype._process = function (pattern, index, inGlobStar) {
 
   var abs = this._makeAbs(read)
 
+  //if ignored, skip processing
+  if(isIgnored(this, read, true))
+    return
+
   var isGlobStar = remain[0] === minimatch.GLOBSTAR
   if (isGlobStar)
     this._processGlobStar(prefix, read, abs, remain, index, inGlobStar)
   else
     this._processReaddir(prefix, read, abs, remain, index, inGlobStar)
 }
+
 
 GlobSync.prototype._processReaddir = function (prefix, read, abs, remain, index, inGlobStar) {
   var entries = this._readdir(abs, inGlobStar)

--- a/test/bash-results.json
+++ b/test/bash-results.json
@@ -101,6 +101,8 @@
     "./test/global-leakage.js",
     "./test/globstar-match.js",
     "./test/has-magic.js",
+    "./test/ignore-sync.js",
+    "./test/ignore.js",
     "./test/mark-sync.js",
     "./test/mark.js",
     "./test/negation-test.js",

--- a/test/ignore-sync.js
+++ b/test/ignore-sync.js
@@ -1,0 +1,151 @@
+require('./global-leakage.js')
+// Ignore option test
+// Show that glob ignores results matching pattern on ignore option
+
+var glob = require('../glob.js')
+var test = require('tap').test
+
+test('get all', function(t) {
+  var results = glob('*', {sync: true, cwd: 'a'})
+  t.same(results, ['abcdef', 'abcfed', 'b', 'bc', 'c', 'cb', 'symlink'])
+  t.end()
+});
+
+test('ignore b', function(t) {
+  var results = glob('*', {sync: true, cwd: 'a', ignore: 'b'})
+  t.same(results, ['abcdef', 'abcfed', 'bc', 'c', 'cb', 'symlink'])
+  t.end()
+});
+
+test('ignore all with first letter as b', function(t) {
+  var results = glob('*', {sync: true, cwd: 'a', ignore: 'b*'});
+  t.same(results, ['abcdef', 'abcfed', 'c', 'cb', 'symlink'])
+  t.end()
+});
+
+test('ignore b/c/d in b/c', function(t) {
+  var results = glob('b/**', {sync: true, cwd: 'a', ignore: 'b/c/d'});
+  t.same(results, ['b', 'b/c'])
+  t.end()
+});
+
+// matches based on pattern specified
+test('ignores d in b/c only if pattern starts with b/c', function(t) {
+  var results = glob('b/**', {sync: true, cwd: 'a', ignore: 'd'});
+  t.same(results, ['b', 'b/c', 'b/c/d'])
+  t.end()
+});
+
+test('ignore b/c and it\'s contents using globstar', function(t) {
+  var results = glob('b/**', {sync: true, cwd: 'a', ignore: 'b/c/**'})
+  t.same(results, ['b'])
+  t.end()
+});
+
+test('ignore, get all d but that in b', function(t) {
+  var results = glob('**/d', {sync: true, cwd: 'a', ignore: 'b/c/d'})
+  t.same(results, ['c/d'])
+  t.end()
+});
+
+test('ignore, get all a/**/[gh] except a/abcfed/g/h', function(t) {
+  var results = glob('a/**/[gh]', {sync: true, ignore: ['a/abcfed/g/h']})
+  t.same(results, ['a/abcdef/g', 'a/abcdef/g/h', 'a/abcfed/g'])
+  t.end()
+});
+
+test('ignore, using multiple ignores', function(t) {
+  var results = glob('*', {sync: true, cwd: 'a', ignore: ['c', 'bc', 'symlink', 'abcdef']})
+  t.same(results, ['abcfed', 'b', 'cb'])
+  t.end()
+});
+
+test('ignore, using multiple ignores and globstar', function(t) {
+  var results = glob('a/**', {sync: true, ignore: ['a/c/**', 'a/bc/**', 'a/symlink/**', 'a/abcdef/**']})
+  t.same(results, ['a', 'a/abcfed', 'a/abcfed/g', 'a/abcfed/g/h', 'a/b', 'a/b/c', 'a/b/c/d', 'a/cb', 'a/cb/e', 'a/cb/e/f'])
+  t.end()
+});
+
+test('ignore a and it\'s contents', function(t) {
+  var results = glob('a/**', {sync: true, ignore: ['a/**']})
+  t.same(results, [])
+  t.end()
+});
+
+test('ignore a and it\'s contents in case of multiple globstars', function(t) {
+  var results = glob('a/**', {sync: true, ignore: ['a/**/**']})
+  t.same(results, [])
+  t.end()
+});
+
+test('ignore, get path\'s matching a/b, exclude only a/b', function(t) {
+  var results = glob('a/b/**', {sync: true, ignore: ['a/b']})
+  t.same(results, ['a/b/c', 'a/b/c/d'])
+  t.end()
+});
+
+test('ignore, get all but b', function(t) {
+  var results = glob('**', {sync: true, cwd: 'a', ignore: ['b']})
+  t.same(results, ["", "abcdef", "abcdef/g", "abcdef/g/h", "abcfed", "abcfed/g", "abcfed/g/h", "b/c", "b/c/d", "bc", "bc/e", "bc/e/f", "c", "c/d", "c/d/c", "c/d/c/b", "cb", "cb/e", "cb/e/f", "symlink", "symlink/a", "symlink/a/b", "symlink/a/b/c"])
+  t.end()
+});
+
+test('ignore, get all but b and c', function(t) {
+  var results = glob('**', {sync: true, cwd: 'a', ignore: ['b', 'c']})
+  t.same(results, ["", "abcdef", "abcdef/g", "abcdef/g/h", "abcfed", "abcfed/g", "abcfed/g/h", "b/c", "b/c/d", "bc", "bc/e", "bc/e/f", "c/d", "c/d/c", "c/d/c/b", "cb", "cb/e", "cb/e/f", "symlink", "symlink/a", "symlink/a/b", "symlink/a/b/c"])
+  t.end()
+});
+
+test('ignore, get all but filenames starting with b', function(t) {
+  var results = glob('**', {sync: true, cwd: 'a', ignore: ['b**']})
+  t.same(results, ["", "abcdef", "abcdef/g", "abcdef/g/h", "abcfed", "abcfed/g", "abcfed/g/h", "b/c", "b/c/d", "bc/e", "bc/e/f", "c", "c/d", "c/d/c", "c/d/c/b", "cb", "cb/e", "cb/e/f", "symlink", "symlink/a", "symlink/a/b", "symlink/a/b/c"])
+  t.end()
+});
+
+test('ignore, get all but files and directories of b', function(t) {
+  var results = glob('**', {sync: true, cwd: 'a', ignore: ['b/**']})
+  t.same(results, ["", "abcdef", "abcdef/g", "abcdef/g/h", "abcfed", "abcfed/g", "abcfed/g/h", "bc", "bc/e", "bc/e/f", "c", "c/d", "c/d/c", "c/d/c/b", "cb", "cb/e", "cb/e/f", "symlink", "symlink/a", "symlink/a/b", "symlink/a/b/c"])
+  t.end()
+});
+
+test('ignore, get all but files and directories starting with b', function(t) {
+  var results = glob('**', {sync: true, cwd: 'a', ignore: ['b**/**']})
+  t.same(results, ["", "abcdef", "abcdef/g", "abcdef/g/h", "abcfed", "abcfed/g", "abcfed/g/h", "c", "c/d", "c/d/c", "c/d/c/b", "cb", "cb/e", "cb/e/f", "symlink", "symlink/a", "symlink/a/b", "symlink/a/b/c"])
+  t.end()
+});
+
+test('ignore, get all but files and directories starting with ab and ending with ef', function(t) {
+  var results = glob('**', {sync: true, cwd: 'a', ignore: ['ab**ef/**']})
+  t.same(results, ["", "abcfed", "abcfed/g", "abcfed/g/h", "b", "b/c", "b/c/d", "bc", "bc/e", "bc/e/f", "c", "c/d", "c/d/c", "c/d/c/b", "cb", "cb/e", "cb/e/f", "symlink", "symlink/a", "symlink/a/b", "symlink/a/b/c"])
+  t.end()
+});
+
+test('ignore, get all but files and directories of abcdef and abcfed', function(t) {
+  var results = glob('**', {sync: true, cwd: 'a', ignore: ['abc{def,fed}/**']})
+  t.same(results, ["", "b", "b/c", "b/c/d", "bc", "bc/e", "bc/e/f", "c", "c/d", "c/d/c", "c/d/c/b", "cb", "cb/e", "cb/e/f", "symlink", "symlink/a", "symlink/a/b", "symlink/a/b/c"])
+  t.end()
+});
+
+test('ignore, get all but files and directories in first subdirectory of abcdef and abcfed', function(t) {
+  var results = glob('**', {sync: true, cwd: 'a', ignore: ['abc{def,fed}/*']})
+  t.same(results, ["", "abcdef", "abcdef/g/h", "abcfed", "abcfed/g/h", "b", "b/c", "b/c/d", "bc", "bc/e", "bc/e/f", "c", "c/d", "c/d/c", "c/d/c/b", "cb", "cb/e", "cb/e/f", "symlink", "symlink/a", "symlink/a/b", "symlink/a/b/c"])
+  t.end()
+});
+
+test('ignore, get all files from c but the first subdirectory/files', function(t) {
+  var results = glob('c/**', {sync: true, cwd: 'a', ignore: ['c/*']})
+  t.same(results, ['c', 'c/d/c', 'c/d/c/b'])
+  t.end()
+});
+
+test('ignore, get all files from c but the first subdirectory/files without cwd option', function(t) {
+  var results = glob('a/c/**', {sync: true, ignore: ['a/c/*']})
+  t.same(results, ['a/c', 'a/c/d/c', 'a/c/d/c/b'])
+  t.end()
+});
+
+test('ignore all files and directories of c', function(t) {
+  var results = glob('a/c/**', {sync: true, ignore: ['a/c/**', 'a/c/*', 'a/c/*/*']})
+  t.same(results, [])
+  t.end()
+});

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -1,0 +1,223 @@
+require('./global-leakage.js')
+// Ignore option test
+// Show that glob ignores results matching pattern on ignore option
+
+var glob = require('../glob.js')
+var test = require('tap').test
+
+test('get all', function(t) {
+  var results = glob('*', {cwd: 'a'}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['abcdef', 'abcfed', 'b', 'bc', 'c', 'cb', 'symlink'])
+    t.end()
+  })
+});
+
+test('ignore b', function(t) {
+  var results = glob('*', {cwd: 'a', ignore: 'b'}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['abcdef', 'abcfed', 'bc', 'c', 'cb', 'symlink'])
+    t.end()
+  })
+});
+
+test('ignore all with first letter as b', function(t) {
+  var results = glob('*', {cwd: 'a', ignore: 'b*'}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['abcdef', 'abcfed', 'c', 'cb', 'symlink'])
+    t.end()
+  });
+});
+
+test('ignore b/c/d in b/c', function(t) {
+  var results = glob('b/**', {cwd: 'a', ignore: 'b/c/d'}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['b', 'b/c'])
+    t.end()
+  });
+});
+
+// matches based on pattern specified
+test('ignores d in b/c only if pattern starts with b/c', function(t) {
+  var results = glob('b/**', {cwd: 'a', ignore: 'd'}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['b', 'b/c', 'b/c/d'])
+    t.end()
+  });
+});
+
+test('ignore b/c and it\'s contents using globstar', function(t) {
+  var results = glob('b/**', {cwd: 'a', ignore: 'b/c/**'}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['b'])
+    t.end()
+  })
+});
+
+test('ignore, get all d but that in b', function(t) {
+  var results = glob('**/d', {cwd: 'a', ignore: 'b/c/d'}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['c/d'])
+    t.end()
+  })
+});
+
+test('ignore, get all a/**/[gh] except a/abcfed/g/h', function(t) {
+  var results = glob('a/**/[gh]', {ignore: ['a/abcfed/g/h']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['a/abcdef/g', 'a/abcdef/g/h', 'a/abcfed/g'])
+    t.end()
+  })
+});
+
+test('ignore, using multiple ignores', function(t) {
+  var results = glob('*', {cwd: 'a', ignore: ['c', 'bc', 'symlink', 'abcdef']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['abcfed', 'b', 'cb'])
+    t.end()
+  })
+});
+
+test('ignore, using multiple ignores and globstar', function(t) {
+  var results = glob('a/**', {ignore: ['a/c/**', 'a/bc/**', 'a/symlink/**', 'a/abcdef/**']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['a', 'a/abcfed', 'a/abcfed/g', 'a/abcfed/g/h', 'a/b', 'a/b/c', 'a/b/c/d', 'a/cb', 'a/cb/e', 'a/cb/e/f'])
+    t.end()
+  })
+});
+
+test('ignore a and it\'s contents', function(t) {
+  var results = glob('a/**', {ignore: ['a/**']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, [])
+    t.end()
+  })
+});
+
+test('ignore a and it\'s contents in case of multiple globstars', function(t) {
+  var results = glob('a/**', {ignore: ['a/**/**']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, [])
+    t.end()
+  })
+});
+
+test('ignore, get path\'s matching a/b, exclude only a/b', function(t) {
+  var results = glob('a/b/**', {ignore: ['a/b']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['a/b/c', 'a/b/c/d'])
+    t.end()
+  })
+});
+
+test('ignore, get all but b', function(t) {
+  var results = glob('**', {cwd: 'a', ignore: ['b']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['', 'abcdef', 'abcdef/g', 'abcdef/g/h', 'abcfed', 'abcfed/g', 'abcfed/g/h', 'b/c', 'b/c/d', 'bc', 'bc/e', 'bc/e/f', 'c', 'c/d', 'c/d/c', 'c/d/c/b', 'cb', 'cb/e', 'cb/e/f', 'symlink', 'symlink/a', 'symlink/a/b', 'symlink/a/b/c'])
+    t.end()
+  })
+});
+
+test('ignore, get all but b and c', function(t) {
+  var results = glob('**', {cwd: 'a', ignore: ['b', 'c']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['', 'abcdef', 'abcdef/g', 'abcdef/g/h', 'abcfed', 'abcfed/g', 'abcfed/g/h', 'b/c', 'b/c/d', 'bc', 'bc/e', 'bc/e/f', 'c/d', 'c/d/c', 'c/d/c/b', 'cb', 'cb/e', 'cb/e/f', 'symlink', 'symlink/a', 'symlink/a/b', 'symlink/a/b/c'])
+    t.end()
+  })
+});
+
+test('ignore, get all but filenames starting with b', function(t) {
+  var results = glob('**', {cwd: 'a', ignore: ['b**']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['', 'abcdef', 'abcdef/g', 'abcdef/g/h', 'abcfed', 'abcfed/g', 'abcfed/g/h', 'b/c', 'b/c/d', 'bc/e', 'bc/e/f', 'c', 'c/d', 'c/d/c', 'c/d/c/b', 'cb', 'cb/e', 'cb/e/f', 'symlink', 'symlink/a', 'symlink/a/b', 'symlink/a/b/c'])
+    t.end()
+  })
+});
+
+test('ignore, get all but files and directories of b', function(t) {
+  var results = glob('**', {cwd: 'a', ignore: ['b/**']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['', 'abcdef', 'abcdef/g', 'abcdef/g/h', 'abcfed', 'abcfed/g', 'abcfed/g/h', 'bc', 'bc/e', 'bc/e/f', 'c', 'c/d', 'c/d/c', 'c/d/c/b', 'cb', 'cb/e', 'cb/e/f', 'symlink', 'symlink/a', 'symlink/a/b', 'symlink/a/b/c'])
+    t.end()
+  })
+});
+
+test('ignore, get all but files and directories starting with b ', function(t) {
+  var results = glob('**', {cwd: 'a', ignore: ['b**/**']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['', 'abcdef', 'abcdef/g', 'abcdef/g/h', 'abcfed', 'abcfed/g', 'abcfed/g/h', 'c', 'c/d', 'c/d/c', 'c/d/c/b', 'cb', 'cb/e', 'cb/e/f', 'symlink', 'symlink/a', 'symlink/a/b', 'symlink/a/b/c'])
+    t.end()
+  })
+});
+
+test('ignore, get all but files and directories starting with ab and ending with ef', function(t) {
+  var results = glob('**', {cwd: 'a', ignore: ['ab**ef/**']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['', 'abcfed', 'abcfed/g', 'abcfed/g/h', 'b', 'b/c', 'b/c/d', 'bc', 'bc/e', 'bc/e/f', 'c', 'c/d', 'c/d/c', 'c/d/c/b', 'cb', 'cb/e', 'cb/e/f', 'symlink', 'symlink/a', 'symlink/a/b', 'symlink/a/b/c'])
+    t.end()
+  })
+});
+
+test('ignore, get all but files and directories of abcdef and abcfed', function(t) {
+  var results = glob('**', {cwd: 'a', ignore: ['abc{def,fed}/**']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['', 'b', 'b/c', 'b/c/d', 'bc', 'bc/e', 'bc/e/f', 'c', 'c/d', 'c/d/c', 'c/d/c/b', 'cb', 'cb/e', 'cb/e/f', 'symlink', 'symlink/a', 'symlink/a/b', 'symlink/a/b/c'])
+    t.end()
+  })
+});
+
+test('ignore, get all but files and directories in first subdirectory/files of abcdef and abcfed', function(t) {
+  var results = glob('**', {cwd: 'a', ignore: ['abc{def,fed}/*']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['', 'abcdef', 'abcdef/g/h', 'abcfed', 'abcfed/g/h', 'b', 'b/c', 'b/c/d', 'bc', 'bc/e', 'bc/e/f', 'c', 'c/d', 'c/d/c', 'c/d/c/b', 'cb', 'cb/e', 'cb/e/f', 'symlink', 'symlink/a', 'symlink/a/b', 'symlink/a/b/c'])
+    t.end()
+  })
+});
+
+test('ignore, get all files from c but the first subdirectory/files with cwd option', function(t) {
+  var results = glob('c/**', {cwd: 'a', ignore: ['c/*']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['c', 'c/d/c', 'c/d/c/b'])
+    t.end()
+  })
+});
+
+test('ignore, get all files from c but the first subdirectory/files without cwd option', function(t) {
+  var results = glob('a/c/**', {ignore: ['a/c/*']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, ['a/c', 'a/c/d/c', 'a/c/d/c/b'])
+    t.end()
+  })
+});
+
+test('ignore all files and directories of c', function(t) {
+  var results = glob('a/c/**', {ignore: ['a/c/**', 'a/c/*', 'a/c/*/c']}, function (er, results) {
+    if (er)
+      throw er
+    t.same(results, [])
+    t.end()
+  })
+});


### PR DESCRIPTION
fixes #115 

In addition to ```minimatch``` check, the code checks if a particular pattern ends with a glob star ```**```, if it does, adds the directory to the ignore list and stops traversal for the directory matching the pattern. 

Also, if, for example, ```a/**``` is added to the ignore list, it removes ```a``` from the resulting match list.