### PR TITLE
Glob sync: trailing slash fix

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -333,8 +333,7 @@ GlobSync.prototype._processSimple = function (prefix, index) {
   if (!this.matches[index])
     this.matches[index] = Object.create(null)
 
-  // If it doesn't exist or isn't a file or dir, then just
-  // mark the lack of results
+  // If it doesn't exist, then just mark the lack of results
   if (!prefixStat)
     return
 
@@ -377,14 +376,9 @@ GlobSync.prototype._stat = function (f) {
     if (Array.isArray(c))
       c = 'DIR'
 
-    // It exists, but not how we need it
-    if (abs.slice(-1) === '/' && c !== 'DIR')
-      return false
-
     return c
   }
 
-  var exists
   var stat = this.statCache[abs]
   if (!stat) {
     try {

--- a/sync.js
+++ b/sync.js
@@ -348,11 +348,11 @@ GlobSync.prototype._processSimple = function (prefix, index) {
     }
   }
 
-  if (prefixStat !== "DIR" && prefix.slice(-1) === "/")
-    return
-
   if (process.platform === 'win32')
     prefix = prefix.replace(/\\/g, '/')
+
+  if (prefixStat !== "DIR" && prefix.slice(-1) === "/")
+    return
 
   // Mark this as a match
   this.matches[index][prefix] = true


### PR DESCRIPTION
This PR fixes #158.

#### `GlobSync.prototype._processSimple`

* **Line 331** Renamed `exists` to `prefixStat` so that it’d make sense when I’d refer to it later.
* **Line 367**: `abs` was being built with `path.resolve`, but `path.resolve` trims the trailing slash off files and folder paths, which means any trailing slash check on `abs` will always be negative. I switched it to `path.join` instead.
* **Lines 364-367**: The absolute path wasn’t being “absoluteified”  in a few cases, so I fixed that.


#### `GlobSync.prototype._stat`

* **Line 386**: `fs.statSync` comes undone if a file path ends in a slash but isn’t a directory, so I’m running `path.resolve` on it before `fs.statSync`.
* **Line 395-397**: `_stat` was returning false if `abs` ended with a slash but wasn’t a directory, but hey, that’s not its job, that’s `_processSimple`’s job, so I moved it up there. Also, since the trailing slash was being `resolve`d away that particular blob of code would never ever run. Poor lil guy.


Hope this all makes sense :cold_sweat: 

Ran tests with `npm test`, everything looks good.