### PR TITLE
quote the versions in .travis.yml so they're matched correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.11
+  - 'iojs'
+  - '0.12'
+  - '0.10'


### PR DESCRIPTION
The current one matches Node `0.1` and `0.11`.

Also test on `iojs`.