### PR TITLE
Unc path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+# http://www.appveyor.com/docs/appveyor-yml
+
+# Fix line endings in Windows. (runs before repo cloning)
+init:
+  - git config --global core.autocrlf true
+
+# Test against these versions of Node.js.
+environment:
+  matrix:
+    - nodejs_version: "0.10"
+    - nodejs_version: "0.12"
+    - nodejs_version: "4.2"
+    - nodejs_version: "5"
+
+# Install scripts. (runs after repo cloning)
+install:
+  - git rev-parse HEAD
+  - md C:\nc
+  - npm config set cache C:\nc
+  - npm version
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - npm version
+  - cmd: npm run test
+
+# Don't actually build.
+build: off
+
+# Set build version format here instead of in the admin panel.
+version: "{build}"

--- a/glob.js
+++ b/glob.js
@@ -45,9 +45,7 @@ var minimatch = require('minimatch')
 var Minimatch = minimatch.Minimatch
 var inherits = require('inherits')
 var EE = require('events').EventEmitter
-var path = require('path')
 var assert = require('assert')
-var isAbsolute = require('path-is-absolute')
 var globSync = require('./sync.js')
 var common = require('./common.js')
 var alphasort = common.alphasort
@@ -58,7 +56,7 @@ var inflight = require('inflight')
 var util = require('util')
 var childrenIgnored = common.childrenIgnored
 var isIgnored = common.isIgnored
-
+var path = require('path')
 var once = require('once')
 
 function glob (pattern, options, cb) {
@@ -320,8 +318,8 @@ Glob.prototype._process = function (pattern, index, inGlobStar, cb) {
   var read
   if (prefix === null)
     read = '.'
-  else if (isAbsolute(prefix) || isAbsolute(pattern.join('/'))) {
-    if (!prefix || !isAbsolute(prefix))
+  else if (this.isAbsolute(prefix) || this.isAbsolute(pattern.join('/'))) {
+    if (!prefix || !this.isAbsolute(prefix))
       prefix = '/' + prefix
     read = prefix
   } else
@@ -651,18 +649,18 @@ Glob.prototype._processSimple2 = function (prefix, index, er, exists, cb) {
   if (!exists)
     return cb()
 
-  if (prefix && isAbsolute(prefix) && !this.nomount) {
+  if (prefix && this.isAbsolute(prefix) && !this.nomount) {
     var trail = /[\/\\]$/.test(prefix)
     if (prefix.charAt(0) === '/') {
       prefix = path.join(this.root, prefix)
     } else {
-      prefix = path.resolve(this.root, prefix)
+      prefix = this.resolve(this.root, prefix)
       if (trail)
         prefix += '/'
     }
   }
 
-  if (process.platform === 'win32')
+  if (this.platform === 'win32')
     prefix = prefix.replace(/\\/g, '/')
 
   // Mark this as a match

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "mkdirp": "0",
+    "path-win32": "^1.0.1",
     "rimraf": "^2.2.8",
     "tap": "^1.1.4",
     "tick": "0.0.6"

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "scripts": {
     "prepublish": "npm run benchclean",
-    "profclean": "rm -f v8.log profile.txt",
-    "test": "tap test/*.js --cov",
+    "profclean": "rimraf v8.log profile.txt",
+    "test": "npm run profclean && tap test/*.js",
     "test-regen": "npm run profclean && TEST_REGEN=1 node test/00-setup.js",
     "bench": "bash benchmark.sh",
     "prof": "bash prof.sh && cat profile.txt",

--- a/sync.js
+++ b/sync.js
@@ -8,7 +8,6 @@ var Glob = require('./glob.js').Glob
 var util = require('util')
 var path = require('path')
 var assert = require('assert')
-var isAbsolute = require('path-is-absolute')
 var common = require('./common.js')
 var alphasort = common.alphasort
 var alphasorti = common.alphasorti
@@ -110,8 +109,8 @@ GlobSync.prototype._process = function (pattern, index, inGlobStar) {
   var read
   if (prefix === null)
     read = '.'
-  else if (isAbsolute(prefix) || isAbsolute(pattern.join('/'))) {
-    if (!prefix || !isAbsolute(prefix))
+  else if (this.isAbsolute(prefix) || this.isAbsolute(pattern.join('/'))) {
+    if (!prefix || !this.isAbsolute(prefix))
       prefix = '/' + prefix
     read = prefix
   } else
@@ -376,7 +375,7 @@ GlobSync.prototype._processSimple = function (prefix, index) {
   if (!exists)
     return
 
-  if (prefix && isAbsolute(prefix) && !this.nomount) {
+  if (prefix && this.isAbsolute(prefix) && !this.nomount) {
     var trail = /[\/\\]$/.test(prefix)
     if (prefix.charAt(0) === '/') {
       prefix = path.join(this.root, prefix)

--- a/test/setopts.js
+++ b/test/setopts.js
@@ -1,0 +1,35 @@
+var test = require("tap").test
+var setopts = require("../common").setopts;
+
+function stubPlatform(platform, fn) {
+  var descriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  try {
+    Object.defineProperty(process, 'platform', { 
+      value: platform,
+      writable: false
+    });
+
+    fn();
+  } finally {
+    Object.defineProperty(process, 'platform', descriptor);
+  }
+
+}
+
+test("unit test – setopts – ensure UNC paths are handled correctly", function (t) {
+
+  stubPlatform("win32", function() {
+    var sentinel = { }
+    setopts(sentinel, "\\\\vmware-host\\Shared Folders\\-folder\\*", { platform: 'win32' })
+    t.same(sentinel.minimatch.pattern, "\\-folder\\\*")
+  })
+
+  stubPlatform("darwin", function() {
+    var sentinel = { }
+    setopts(sentinel, "\\\\vmware-host\\Shared Folders\\-folder\\*", { platform: 'darwin' })
+    t.same(sentinel.minimatch.pattern, "\\\\vmware-host\\Shared Folders\\-folder\\*")
+  })
+
+  t.end()
+})

--- a/test/unc-path.js
+++ b/test/unc-path.js
@@ -1,0 +1,71 @@
+var test = require('tap').test;
+var glob = require('../');
+var fs = require('fs');
+var path = require('path');
+
+test('glob doesn\'t choke on UNC paths', function(t) {
+  stubPlatform('win32', function(restorePlatform) {
+    var readdir = fs.readdir;
+
+    fs.readdir = function(path, cb) {
+      if (path === '\\\\vmware-share\\share-name\\baz') {
+        return cb(undefined, [
+          'some-file.txt',
+          'some-other-file.txt'
+        ])
+      }
+
+      readdir(path, cb)
+    }
+
+    var results = glob('\\\\vmware-share\\share-name\\baz\\*', function (er, results) {
+      restorePlatform();
+
+      if (er)
+        throw er
+
+      t.same(results, [
+        '\\\\vmware-share\\share-name\\baz\\some-file.txt',
+        '\\\\vmware-share\\share-name\\baz\\some-other-file.txt'
+      ])
+
+      t.end()
+    }, { platform: 'win32' })
+  })
+})
+
+function stubPlatform(platform, fn) {
+  var descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+  var path = require('path');
+  var join = path.join;
+  var normalize = path.normalize;
+  var sep = path.sep;
+  var resolve = path.resolve;
+  var isAbsolute = require('path-is-absolute');
+
+  function restore() {
+    path.resolve = resolve;
+    path.sep = sep;
+    path.join = join;
+    path.normalize = normalize;
+    var isAbsolute = require('path-is-absolute');
+    Object.defineProperty(process, 'platform', descriptor);
+  }
+
+  try {
+    Object.defineProperty(process, 'platform', {
+      value: platform,
+      writable: false
+    });
+
+    path.sep = '\\';
+    path.resolve = path[platform].resolve;
+    path.join = path.win32.join;
+    path.normalize = path.win32.normalize;
+
+    return fn(restore);
+  } catch(e) {
+    restore();
+    throw e;
+  }
+}

--- a/test/unc-path.js
+++ b/test/unc-path.js
@@ -2,8 +2,12 @@ var test = require('tap').test;
 var glob = require('../');
 var fs = require('fs');
 var path = require('path');
+var skip = false
+if (/^v0\.(10|[0-9])\./.test(process.version)) {
+  skip = 'Does not work on Node < 0.12'
+}
 
-test('glob doesn\'t choke on UNC paths', function(t) {
+test('glob doesn\'t choke on UNC paths', { skip: skip }, function(t) {
   stubPlatform('win32', function(restorePlatform) {
     var readdir = fs.readdir;
 

--- a/test/win-path.js
+++ b/test/win-path.js
@@ -1,0 +1,72 @@
+var WinPath = require('../common').WinPath;
+var test = require('tap').test
+
+test("UNIT: WinPath – basic path", function(t) {
+  var path = new WinPath('basic-path')
+
+  t.same(path.device, '');
+  t.same(path.sep, '');
+  t.same(path.tail, 'basic-path')
+
+  t.end();
+});
+
+test("UNIT: WinPath – relative path", function(t) {
+  var path = new WinPath('relative\\path')
+
+  t.same(path.device, '');
+  t.same(path.sep, '');
+  t.same(path.tail, 'relative\\path')
+
+  t.end();
+});
+
+test("UNIT: WinPath – relative path \w glob", function(t) {
+  var path = new WinPath('relative\\path\\*')
+
+  t.same(path.device, '');
+  t.same(path.sep, '');
+  t.same(path.tail, 'relative\\path\\*')
+
+  t.end();
+});
+
+test("UNIT: WinPath – absolute path", function(t) {
+  var path = new WinPath('\\relative\\path')
+
+  t.same(path.device, '');
+  t.same(path.sep, '\\');
+  t.same(path.tail, 'relative\\path')
+
+  t.end();
+});
+
+test("UNIT: WinPath – absolute path \w glob", function(t) {
+  var path = new WinPath('\\relative\\path\\*')
+
+  t.same(path.device, '');
+  t.same(path.sep, '\\');
+  t.same(path.tail, 'relative\\path\\*')
+
+  t.end();
+});
+
+test("UNIT: WinPath – UNC path", function(t) {
+  var path = new WinPath('\\\\vmware-share\\share-name\\relative\\path')
+
+  t.same(path.device, '\\\\vmware-share\\share-name');
+  t.same(path.sep, '\\');
+  t.same(path.tail, 'relative\\path')
+
+  t.end();
+});
+
+test("UNIT: WinPath – UNC path \w glob", function(t) {
+  var path = new WinPath('\\\\vmware-share\\share-name\\relative\\path\\*')
+
+  t.same(path.device, '\\\\vmware-share\\share-name');
+  t.same(path.sep, '\\');
+  t.same(path.tail, 'relative\\path\\*')
+
+  t.end();
+});


### PR DESCRIPTION
This is a hybrid of @staticshock and my work.
- unit tests that cover the actual `WinPath` implementation
- integration test – using `mock-fs` and some `path.sep` and `path.resolve` faking, simulate the windows environemnt.
- [x] pending minimatch fix – it doesn't have mock-friendly platform specific code
  - [x] PR https://github.com/isaacs/minimatch/pull/63
  - [x] merge + release
- [x] feedback
- [x] re-confirm the latest refactoring still solves the original issue – it was earlier

---

future work:
- [ ] get tests passing on windows
  - [x] make tests at-least run
  - [ ] make them all pass
- [ ] appveyor
