### PR TITLE
:memo: `2` became `DIR` and `1` became `FILE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ be immediately available on the `g.found` member.
   values:
   * `false` - Path does not exist
   * `true` - Path exists
-  * `'DIR'` - Path exists, and is not a directory
-  * `'FILE'` - Path exists, and is a directory
+  * `'FILE'` - Path exists, and is not a directory
+  * `'DIR'` - Path exists, and is a directory
   * `[file, entries, ...]` - Path exists, is a directory, and the
     array value is the results of `fs.readdir`
 * `statCache` Cache of `fs.stat` results, to prevent statting the same


### PR DESCRIPTION
Minor doc change

Error introduced here : https://github.com/isaacs/node-glob/commit/d2aecbf0869c98732e5e448429963b62a80c2ec8#diff-04c6e90faac2675aa89e2176d2eec7d8R157 

Verified that `2` should have been called `DIR` from code as well : https://github.com/isaacs/node-glob/commit/9f28ef2e0ecef7c619cda5023188f3df196acde3#diff-654b8ff873ba9ba5bb73fbdb291c2018L260 :rose:

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/isaacs/node-glob/222)
<!-- Reviewable:end -->
