### PR TITLE
Breaking change in 6.0.2

### DIFF
--- a/common.js
+++ b/common.js
@@ -104,6 +104,11 @@ function setopts (self, pattern, options) {
 
   self.nomount = !!options.nomount
 
+  // disable comments and negation unless the user explicitly
+  // passes in false as the option.
+  options.nonegate = true
+  options.nocomment = true
+
   self.minimatch = new Minimatch(pattern, options)
   self.options = self.minimatch.options
 }


### PR DESCRIPTION
eb6319ff5 broke backward compatibility for me.
I do not yet have a simple example to take a look at, but I have isolated the breakage to this single file change.

From looking at the commit the change seems surely functional - the option defaults have been changed!
