### PR TITLE
Fix follow behaviour

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -490,7 +490,7 @@ Glob.prototype._readdirInGlobStar = function (abs, cb) {
       self.cache[abs] = 'FILE'
       cb()
     } else
-      if (!isSym || this.follow ) {
+      if (!isSym || this.follow) {
         self._readdir(abs, false, cb)
       } else {
         cb()

--- a/glob.js
+++ b/glob.js
@@ -490,7 +490,11 @@ Glob.prototype._readdirInGlobStar = function (abs, cb) {
       self.cache[abs] = 'FILE'
       cb()
     } else
-      self._readdir(abs, false, cb)
+      if (!isSym || this.follow ) {
+        self._readdir(abs, false, cb)
+      } else {
+        cb()
+      }
   }
 }
 

--- a/sync.js
+++ b/sync.js
@@ -250,8 +250,13 @@ GlobSync.prototype._readdirInGlobStar = function (abs) {
   // don't bother doing a readdir in that case.
   if (!isSym && !lstat.isDirectory())
     this.cache[abs] = 'FILE'
-  else
-    entries = this._readdir(abs, false)
+  else {
+    if (!isSym || this.follow) {
+        entries = this._readdir(abs, false)
+    } else {
+        entries = [];
+    }
+  }
 
   return entries
 }
@@ -340,15 +345,16 @@ GlobSync.prototype._processGlobStar = function (prefix, read, abs, remain, index
   var gspref = prefix ? [ prefix ] : []
   var noGlobStar = gspref.concat(remainWithoutGlobStar)
 
-  // the noGlobStar pattern exits the inGlobStar state
-  this._process(noGlobStar, index, false)
-
   var len = entries.length
   var isSym = this.symlinks[abs]
 
   // If it's a symlink, and we're in a globstar, then stop
   if (isSym && inGlobStar)
     return
+
+  // the noGlobStar pattern exits the inGlobStar state
+  this._process(noGlobStar, index, false)
+
 
   for (var i = 0; i < len; i++) {
     var e = entries[i]

--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -102,7 +102,7 @@ var globs =
   ,"{./*/*,/tmp/glob-test/*}"
   ,"{/tmp/glob-test/*,*}" // evil owl face!  how you taunt me!
   ,"a/!(symlink)/**"
-  ,"a/symlink/a/**/*"
+  ,"a/symlink/a/**"
   ]
 var bashOutput = {}
 var fs = require("fs")

--- a/test/bash-results.json
+++ b/test/bash-results.json
@@ -132,9 +132,9 @@
     "a/x",
     "a/z"
   ],
-  "a/symlink/a/**/*": [
+  "a/symlink/a/**": [
+    "a/symlink/a",
     "a/symlink/a/b",
-    "a/symlink/a/b/c",
-    "a/symlink/a/b/c/a"
+    "a/symlink/a/b/c"
   ]
 }

--- a/test/match-base.js
+++ b/test/match-base.js
@@ -11,7 +11,7 @@ var expect = [
 ]
 
 if (process.platform !== 'win32')
-  expect.push('a/symlink/a', 'a/symlink/a/b/c/a')
+  expect.push('a/symlink/a')
 
 t.test('chdir', function (t) {
   var origCwd = process.cwd()

--- a/test/ok-symlink.js
+++ b/test/ok-symlink.js
@@ -23,9 +23,9 @@ test('set up working symlink', function (t) {
   fs.symlinkSync('../working-target', 'a/working-link/link')
   t.end()
 })
-/*
+
 test('async follow test', function (t) {
-  var pattern = 'a/working-* /** /*.js';
+  var pattern = 'a/working-*/**/*.js';
   var expected = [
     'a/working-target/file.js',
     'a/working-link/link/file.js',
@@ -48,7 +48,7 @@ test('async follow test', function (t) {
 })
 
 test('async nofollow test', function (t) {
-  var pattern = 'a/working-* /** /*.js';
+  var pattern = 'a/working-*/**/*.js';
   var expected = [
     'a/working-target/file.js',
   ];
@@ -70,7 +70,7 @@ test('async nofollow test', function (t) {
 })
 
 test('sync follow test', function (t) {
-  var pattern = 'a/working-* /** /*.js';
+  var pattern = 'a/working-*/**/*.js';
   var expected = [
     'a/working-target/file.js',
     'a/working-link/link/file.js',
@@ -86,7 +86,7 @@ test('sync follow test', function (t) {
   });
   t.end();
 })
-*/
+
 test('sync nofollow test', function (t) {
   var pattern = 'a/working-*/**/*.js';
   var expected = [

--- a/test/ok-symlink.js
+++ b/test/ok-symlink.js
@@ -1,0 +1,118 @@
+var fs = require('fs')
+var test = require('tap').test
+var glob = require('../')
+var mkdirp = require('mkdirp')
+
+if (process.platform === 'win32')
+  return require('tap').plan(0, 'skip on windows')
+
+process.chdir(__dirname)
+
+var link = 'a/working-link/link/file'
+
+var patterns = [
+  'a/working-link/**',
+]
+
+test('set up working symlink', function (t) {
+  cleanup()
+  mkdirp.sync('a/working-link')
+  mkdirp.sync('a/working-target');
+  fs.writeFileSync('a/working-target/file.js','Content');
+  fs.writeFileSync('a/working-target/file.txt','Content');
+  fs.symlinkSync('../working-target', 'a/working-link/link')
+  t.end()
+})
+/*
+test('async follow test', function (t) {
+  var pattern = 'a/working-* /** /*.js';
+  var expected = [
+    'a/working-target/file.js',
+    'a/working-link/link/file.js',
+  ];
+  glob(pattern, {follow:true}, cb())
+
+  function cb () {
+      return function (er, res) {
+          if (er) throw er
+          var msg = pattern + ' '
+          res.forEach(function(item){
+              t.notEqual(-1, expected.indexOf(item), msg + ' ' + item + ' found but not expected')
+          });
+          expected.forEach(function(item){
+              t.notEqual(-1, res.indexOf(item), msg + ' ' + item + ' expected but not found')
+          });
+          t.end();
+      }
+  }
+})
+
+test('async nofollow test', function (t) {
+  var pattern = 'a/working-* /** /*.js';
+  var expected = [
+    'a/working-target/file.js',
+  ];
+  glob(pattern, {follow:false}, cb())
+
+  function cb () {
+      return function (er, res) {
+          if (er) throw er
+          var msg = pattern + ' '
+          res.forEach(function(item){
+              t.notEqual(-1, expected.indexOf(item), msg + ' ' + item + ' found but not expected')
+          });
+          expected.forEach(function(item){
+              t.notEqual(-1, res.indexOf(item), msg + ' ' + item + ' expected but not found')
+          });
+          t.end();
+      }
+  }
+})
+
+test('sync follow test', function (t) {
+  var pattern = 'a/working-* /** /*.js';
+  var expected = [
+    'a/working-target/file.js',
+    'a/working-link/link/file.js',
+  ];
+  res = glob.sync(pattern, {follow:true});
+
+  var msg = pattern + ' '
+  res.forEach(function(item){
+      t.notEqual(-1, expected.indexOf(item), msg + ' ' + item + ' found but not expected')
+  });
+  expected.forEach(function(item){
+      t.notEqual(-1, res.indexOf(item), msg + ' ' + item + ' expected but not found')
+  });
+  t.end();
+})
+*/
+test('sync nofollow test', function (t) {
+  var pattern = 'a/working-*/**/*.js';
+  var expected = [
+    'a/working-target/file.js',
+  ];
+  res = glob.sync(pattern, {follow:false});
+
+  var msg = pattern + ' '
+  res.forEach(function(item){
+      t.notEqual(-1, expected.indexOf(item), msg + ' ' + item + ' found but not expected')
+  });
+  expected.forEach(function(item){
+      t.notEqual(-1, res.indexOf(item), msg + ' ' + item + ' expected but not found')
+  });
+  t.end();
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  try { fs.unlinkSync('a/working-link/link') } catch (e) {}
+  try { fs.unlinkSync('a/working-target/file.js') } catch (e) {}
+  try { fs.unlinkSync('a/working-target/file.txt') } catch (e) {}
+  try { fs.rmdirSync('a/working-link') } catch (e) {}
+  try { fs.rmdirSync('a/working-target') } catch (e) {}
+}


### PR DESCRIPTION
I noticed bad symlink following behaviour from eslint usage which results in scanning files within symlinked directories even with follow:false set.

This PR fixes async and sync behaviour, adds tests for both in the specific eslint use case and deals with a bash oddity:  whilst ** doesn't follow a symlink **/* will.  This may be an edge-case bug in the bash implementation too - but I don't want to follow this rabbit-hole any deeper right now.
