### PR TITLE
Simplify extend function

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -81,14 +81,10 @@ var GlobSync = glob.GlobSync = globSync.GlobSync
 glob.glob = glob
 
 function extend (origin, add) {
-  if (add === null || typeof add !== 'object') {
-    return origin
-  }
-
-  var keys = Object.keys(add)
-  var i = keys.length
-  while (i--) {
-    origin[keys[i]] = add[keys[i]]
+  if (add !== null && typeof add === 'object') {
+    for (var key in add) {
+      origin[key] = add[key];
+    }
   }
   return origin
 }


### PR DESCRIPTION
Instead of creatin a temporary array of all they keys of the ‘add’
object, simply iterate over them using for-in construct instead.
This makes the code shorter and, as hinted above, gets rid of an
unnecessary array.  The patch also changes the function to have
single return which is also nice.