### PR TITLE
Fixed error in hasMagic function

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -103,6 +103,9 @@ glob.hasMagic = function (pattern, options_) {
   if (set.length > 1)
     return true
 
+  if (set.length === 0)
+    return false
+
   for (var j = 0; j < set[0].length; j++) {
     if (typeof set[0][j] !== 'string')
       return true

--- a/test/has-magic.js
+++ b/test/has-magic.js
@@ -14,12 +14,17 @@ test("create glob object without processing", function (t) {
 })
 
 test("detect magic in glob patterns", function (t) {
-  t.notOk(glob.hasMagic("a/b/c/"), "no magic a/b/c/")
+  t.notOk(glob.hasMagic("a/b/c/"), "no magic in a/b/c/")
   t.ok(glob.hasMagic("a/b/**/"), "magic in a/b/**/")
   t.ok(glob.hasMagic("a/b/?/"), "magic in a/b/?/")
   t.ok(glob.hasMagic("a/b/+(x|y)"), "magic in a/b/+(x|y)")
   t.notOk(glob.hasMagic("a/b/+(x|y)", {noext:true}), "no magic in a/b/+(x|y) noext")
   t.ok(glob.hasMagic('{a,b}'), 'magic in {a,b}')
   t.notOk(glob.hasMagic('{a,b}', {nobrace:true}), 'magic in {a,b} nobrace:true')
+  t.end()
+})
+
+test("ensure empty pattern does not throw error", function (t) {
+  t.notOk(glob.hasMagic(""), "no magic ''")
   t.end()
 })


### PR DESCRIPTION
Fixed issue where empty pattern to hasMagic caused a TypeError.

Repro steps in node REPL:
```
> var glob = require('glob');
> glob.hasMagic('');
TypeError: Cannot read property 'length' of undefined
    at Function.glob.hasMagic (/........../node_modules/glob/glob.js:106:29)
    ...
```