### PR TITLE
Updated `mimimatch` dependence

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fs.realpath": "^1.0.0",
     "inflight": "^1.0.4",
     "inherits": "2",
-    "minimatch": "2 || 3",
+    "minimatch": "^3.0.2",
     "once": "^1.3.0",
     "path-is-absolute": "^1.0.0"
   },


### PR DESCRIPTION
Which generated this error

```
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```
(a more colorful one) down the line.
