### PR TITLE
Add `absolute` option for match event - closes #292

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ the filesystem.
   In the case of a symlink that cannot be resolved, the full absolute
   path to the matched entry is returned (though it will usually be a
   broken symlink)
+* `absolute` Set to true to always receive absolute paths for the
+  `'match'` event. Will not pass absolute paths to the callback
+  or returned from `glob.sync`.
 
 ## Comparisons to other fnmatch/glob implementations
 

--- a/common.js
+++ b/common.js
@@ -80,6 +80,7 @@ function setopts (self, pattern, options) {
   self.nocase = !!options.nocase
   self.stat = !!options.stat
   self.noprocess = !!options.noprocess
+  self._absolute = !!options.absolute
 
   self.maxLength = options.maxLength || Infinity
   self.cache = options.cache || Object.create(null)

--- a/glob.js
+++ b/glob.js
@@ -485,7 +485,7 @@ Glob.prototype._emitMatch = function (index, e) {
   if (st)
     this.emit('stat', e, st)
 
-  this.emit('match', e)
+  this.emit('match', this._absolute ? abs : e)
 }
 
 Glob.prototype._readdirInGlobStar = function (abs, cb) {

--- a/test/absolute.js
+++ b/test/absolute.js
@@ -1,0 +1,23 @@
+require('./global-leakage.js')
+var test = require('tap').test
+var Glob = require('../').Glob
+var common = require('../common.js')
+var pattern = 'a/b/**';
+var bashResults = require('./bash-results.json')
+var isAbsolute = require('path-is-absolute')
+process.chdir(__dirname + '/fixtures')
+
+test('Emits absolute matches if option set', function (t) {
+  var g = new Glob(pattern, { absolute: true })
+
+  var matchCount = 0
+  g.on('match', function (m) {
+    t.ok(isAbsolute(m), 'must be absolute')
+    matchCount++
+  })
+
+  g.on('end', function () {
+    t.equal(matchCount, bashResults[pattern].length, 'must match all files')
+    t.end()
+  })
+})


### PR DESCRIPTION
@isaacs Implemented as per guidance on #292 - I added a note about the caveat that this is only applied to `'match'` events and not to the final results in the callback.  I am not familiar enough with the code to understand the scope of making the final results absolute.  Do you think it's a worth including in this feature?