### PR TITLE
Add failing test for root + absolute option

### DIFF
--- a/common.js
+++ b/common.js
@@ -103,7 +103,11 @@ function setopts (self, pattern, options) {
   if (process.platform === "win32")
     self.root = self.root.replace(/\\/g, "/")
 
-  self.cwdAbs = makeAbs(self, self.cwd)
+  // TODO: is an absolute `cwd` supposed to be resolved against `root`?
+  // e.g. { cwd: '/test', root: __dirname } === path.join(__dirname, '/test')
+  self.cwdAbs = isAbsolute(self.cwd) ? self.cwd : makeAbs(self, self.cwd)
+  if (process.platform === "win32")
+    self.cwdAbs = self.cwdAbs.replace(/\\/g, "/")
   self.nomount = !!options.nomount
 
   // disable comments and negation in Minimatch.

--- a/glob.js
+++ b/glob.js
@@ -465,7 +465,7 @@ Glob.prototype._emitMatch = function (index, e) {
     return
   }
 
-  var abs = this._makeAbs(e)
+  var abs = isAbsolute(e) ? e : this._makeAbs(e)
 
   if (this.mark)
     e = this._mark(e)

--- a/test/root.js
+++ b/test/root.js
@@ -81,3 +81,19 @@ t.test('combined with absolute option', function(t) {
     t.end()
   })
 })
+
+t.test('cwdAbs when root=a, absolute=true', function(t) {
+   var g = glob('/b*/**', { root: path.resolve('a'), absolute: true }, function (er, matches) {
+    t.ifError(er)
+    t.same(g.cwdAbs, process.cwd().replace(/\\/g, '/'))
+    t.end()
+  })
+})
+
+t.test('cwdAbs when root=a, absolute=true, cwd=__dirname', function(t) {
+   var g = glob('/b*/**', { root: path.resolve('a'), absolute: true, cwd: __dirname }, function (er, matches) {
+    t.ifError(er)
+    t.same(g.cwdAbs, __dirname.replace(/\\/g, '/'))
+    t.end()
+  })
+})

--- a/test/root.js
+++ b/test/root.js
@@ -52,3 +52,32 @@ t.test('root=a, cwd=a/b', function (t) {
     t.end()
   })
 })
+
+t.test('combined with absolute option', function(t) {
+  var g = glob('/b*/**', { root: path.resolve('a'), absolute: true }, function (er, matches) {
+    t.ifError(er)
+    /* For some reason this passes even though it compares
+      [ '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/b',
+        '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/b/c',
+        '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/b/c/d',
+        '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/bc',
+        '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/bc/e',
+        '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/bc/e/f' ]
+      to
+      [ '/Users/phated/node-glob/test/fixtures/a/b',
+        '/Users/phated/node-glob/test/fixtures/a/b/c',
+        '/Users/phated/node-glob/test/fixtures/a/b/c/d',
+        '/Users/phated/node-glob/test/fixtures/a/bc',
+        '/Users/phated/node-glob/test/fixtures/a/bc/e',
+        '/Users/phated/node-glob/test/fixtures/a/bc/e/f' ]
+    */
+    // t.like(matches, [ '/b', '/b/c', '/b/c/d', '/bc', '/bc/e', '/bc/e/f' ].map(function (m) {
+    //   return path.join(path.resolve('a'), m).replace(/\\/g, '/')
+    // }))
+    t.same(matches, [ '/b', '/b/c', '/b/c/d', '/bc', '/bc/e', '/bc/e/f' ].map(function (m) {
+      return path.join(path.resolve('a'), m).replace(/\\/g, '/')
+    }))
+    cacheCheck(g, t)
+    t.end()
+  })
+})

--- a/test/root.js
+++ b/test/root.js
@@ -20,7 +20,7 @@ function cacheCheck(g, t) {
 t.test('.', function (t) {
   var g = glob('/b*/**', { root: '.' }, function (er, matches) {
     t.ifError(er)
-    t.like(matches, [])
+    t.same(matches, [])
     cacheCheck(g, t)
     t.end()
   })
@@ -36,7 +36,7 @@ t.test('a', function (t) {
         return path.join(path.resolve('a'), m).replace(/\\/g, '/')
       })
 
-    t.like(matches, wanted)
+    t.same(matches, wanted)
     cacheCheck(g, t)
     t.end()
   })
@@ -45,7 +45,7 @@ t.test('a', function (t) {
 t.test('root=a, cwd=a/b', function (t) {
   var g = glob('/b*/**', { root: 'a', cwd: path.resolve('a/b') }, function (er, matches) {
     t.ifError(er)
-    t.like(matches, [ '/b', '/b/c', '/b/c/d', '/bc', '/bc/e', '/bc/e/f' ].map(function (m) {
+    t.same(matches, [ '/b', '/b/c', '/b/c/d', '/bc', '/bc/e', '/bc/e/f' ].map(function (m) {
       return path.join(path.resolve('a'), m).replace(/\\/g, '/')
     }))
     cacheCheck(g, t)
@@ -56,24 +56,6 @@ t.test('root=a, cwd=a/b', function (t) {
 t.test('combined with absolute option', function(t) {
   var g = glob('/b*/**', { root: path.resolve('a'), absolute: true }, function (er, matches) {
     t.ifError(er)
-    /* For some reason this passes even though it compares
-      [ '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/b',
-        '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/b/c',
-        '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/b/c/d',
-        '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/bc',
-        '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/bc/e',
-        '/Users/phated/node-glob/test/fixtures/a/Users/phated/node-glob/test/fixtures/a/bc/e/f' ]
-      to
-      [ '/Users/phated/node-glob/test/fixtures/a/b',
-        '/Users/phated/node-glob/test/fixtures/a/b/c',
-        '/Users/phated/node-glob/test/fixtures/a/b/c/d',
-        '/Users/phated/node-glob/test/fixtures/a/bc',
-        '/Users/phated/node-glob/test/fixtures/a/bc/e',
-        '/Users/phated/node-glob/test/fixtures/a/bc/e/f' ]
-    */
-    // t.like(matches, [ '/b', '/b/c', '/b/c/d', '/bc', '/bc/e', '/bc/e/f' ].map(function (m) {
-    //   return path.join(path.resolve('a'), m).replace(/\\/g, '/')
-    // }))
     t.same(matches, [ '/b', '/b/c', '/b/c/d', '/bc', '/bc/e', '/bc/e/f' ].map(function (m) {
       return path.join(path.resolve('a'), m).replace(/\\/g, '/')
     }))


### PR DESCRIPTION
Hey @isaacs - with the `absolute` option feature, I encountered a problem that I've created a failing test for.  I am still digging into a solution but I thought I'd get this test in front of you incase you have a better idea of what is happening.

Side note: I have a commented out test using `t.like` which was passing, not sure if I stumbled on a `node-tap` bug while working on this.