### PR TITLE
Fix win32 test failure

### DIFF
--- a/test/eperm-stat.js
+++ b/test/eperm-stat.js
@@ -87,6 +87,11 @@ t.test('globstar with error in root', function (t) {
     'a/x',
     'a/z'
   ]
+  if (process.platform === 'win32') {
+    expect = expect.filter(function(path) {
+      return path.indexOf('/symlink') === -1
+    })
+  }
 
   var pattern = 'a/**'
   t.plan(2)


### PR DESCRIPTION
The test in `eperm-stat.js` fails on Appveyor because the fixtures don't include symlinks. This PR remedies that.
