### PR TITLE
Drop `inherits` dependency in favor of `util.inherits` in Node itself.

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -44,7 +44,6 @@ var fs = require('fs')
 var rp = require('fs.realpath')
 var minimatch = require('minimatch')
 var Minimatch = minimatch.Minimatch
-var inherits = require('inherits')
 var EE = require('events').EventEmitter
 var path = require('path')
 var assert = require('assert')
@@ -116,7 +115,7 @@ glob.hasMagic = function (pattern, options_) {
 }
 
 glob.Glob = Glob
-inherits(Glob, EE)
+util.inherits(Glob, EE)
 function Glob (pattern, options, cb) {
   if (typeof options === 'function') {
     cb = options

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "fs.realpath": "^1.0.0",
     "inflight": "^1.0.4",
-    "inherits": "2",
     "minimatch": "^3.0.2",
     "once": "^1.3.0",
     "path-is-absolute": "^1.0.0"


### PR DESCRIPTION
Not like this supports any other runtimes, anyways...