### PR TITLE
Adds `createFsCache` function for easier IO caching

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -115,6 +115,15 @@ glob.hasMagic = function (pattern, options_) {
   return false
 }
 
+glob.createFsCache = function () {
+  return {
+    cache: Object.create(null),
+    statCache: Object.create(null),
+    symlinks: Object.create(null),
+    realpathCache: Object.create(null)
+  }
+}
+
 glob.Glob = Glob
 inherits(Glob, EE)
 function Glob (pattern, options, cb) {


### PR DESCRIPTION
When running multiple glob operations, I want to cache IO operations across all of them.  The intuitive way to do this, at least for me, looks something like this:

```js
// Create a cache that can be shared across all glob calls
const fsCache = glob.createFsCache();
const files1 = glob.sync('**/*.ts', {
  ...fsCache, // using object property spread
  cwd: 'src'
});
const files2 = glob.sync('**/*.{json,js}', Object.assign({ // using a helper function
  cwd: 'src/dependencies/button-widget'
}, fsCache));
```

I create a cache first and then pass it into each glob call.

Without a `glob.createFsCache` function, I would have to start the first glob operation, grab its caching options, and then pass those to subsequent glob calls.  However, that's extra conditional logic and confusion that can be avoided.

Without a `createFsCache` function, my code has to do one or both of:

* manually grab four properties off of a glob object: `realpathCache`, `cache`, `symlinks`, and `statCache`
* Create those objects itself, knowing that they must be objects with a `null` prototype (this is undocumented)

If you think this is worth merging, I can add README documentation to this PR.