### PR TITLE
:bug: Always emit matches asynchronously

### DIFF
--- a/glob.js
+++ b/glob.js
@@ -168,10 +168,12 @@ function Glob (pattern, options, cb) {
     return done()
 
   var sync = true
-  for (var i = 0; i < n; i ++) {
-    this._process(this.minimatch.set[i], i, false, done)
-  }
-  sync = false
+  process.nextTick(function () {
+    for (var i = 0; i < n; i ++) {
+      self._process(self.minimatch.set[i], i, false, done)
+    }
+    sync = false
+  });
 
   function done () {
     --self._processing


### PR DESCRIPTION
Glob may emit match events synchronously when cache are given. And it leads to a race condition, eg:

```javascript
let glob = new Glob(globStr, { cache, symlinks, statCache })

// Wait for glob ends...

glob = new Glob(globStr, { cache, symlinks, statCache }) // <- Emit `match` event immediately
glob.on('match', console.log) // <- Receive nothing
```