### PR TITLE
Exclude larger files from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+oh-my-glob.gif
+test


### PR DESCRIPTION
While looking for larger files in dependencies, I'd noticed a few in `node-glob`.

```
➜  ember.js git:(master) find ./node_modules/fs-sync/node_modules/glob/ -type f | xargs du -sh | sort -rn                                                    
500K    ./node_modules/fs-sync/node_modules/glob//oh-my-glob.gif
 32K    ./node_modules/fs-sync/node_modules/glob//test/bash-results.json
```

Would you consider adding an NPM ignore file to prevent some of these files from being included in package builds?

Thanks for reading!