### PR TITLE
Test to show if 'end' event is emitted properly

### DIFF
--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -103,6 +103,8 @@ var globs =
   ,"{/tmp/glob-test/*,*}" // evil owl face!  how you taunt me!
   ,"a/!(symlink)/**"
   ,"a/symlink/a/**/*"
+  ,"a/*"
+  ,"a/*/**"
   ]
 var bashOutput = {}
 var fs = require("fs")

--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -103,8 +103,7 @@ var globs =
   ,"{/tmp/glob-test/*,*}" // evil owl face!  how you taunt me!
   ,"a/!(symlink)/**"
   ,"a/symlink/a/**/*"
-  ,"a/*"
-  ,"a/*/**"
+  ,"a/!(symlink)"
   ]
 var bashOutput = {}
 var fs = require("fs")

--- a/test/bash-results.json
+++ b/test/bash-results.json
@@ -137,36 +137,13 @@
     "a/symlink/a/b/c",
     "a/symlink/a/b/c/a"
   ],
-  "a/*": [
+  "a/!(symlink)": [
     "a/abcdef",
     "a/abcfed",
     "a/b",
     "a/bc",
     "a/c",
     "a/cb",
-    "a/x",
-    "a/z"
-  ],
-  "a/*/**": [
-    "a/abcdef",
-    "a/abcdef/g",
-    "a/abcdef/g/h",
-    "a/abcfed",
-    "a/abcfed/g",
-    "a/abcfed/g/h",
-    "a/b",
-    "a/b/c",
-    "a/b/c/d",
-    "a/bc",
-    "a/bc/e",
-    "a/bc/e/f",
-    "a/c",
-    "a/c/d",
-    "a/c/d/c",
-    "a/c/d/c/b",
-    "a/cb",
-    "a/cb/e",
-    "a/cb/e/f",
     "a/x",
     "a/z"
   ]

--- a/test/bash-results.json
+++ b/test/bash-results.json
@@ -136,5 +136,38 @@
     "a/symlink/a/b",
     "a/symlink/a/b/c",
     "a/symlink/a/b/c/a"
+  ],
+  "a/*": [
+    "a/abcdef",
+    "a/abcfed",
+    "a/b",
+    "a/bc",
+    "a/c",
+    "a/cb",
+    "a/x",
+    "a/z"
+  ],
+  "a/*/**": [
+    "a/abcdef",
+    "a/abcdef/g",
+    "a/abcdef/g/h",
+    "a/abcfed",
+    "a/abcfed/g",
+    "a/abcfed/g/h",
+    "a/b",
+    "a/b/c",
+    "a/b/c/d",
+    "a/bc",
+    "a/bc/e",
+    "a/bc/e/f",
+    "a/c",
+    "a/c/d",
+    "a/c/d/c",
+    "a/c/d/c/b",
+    "a/cb",
+    "a/cb/e",
+    "a/cb/e/f",
+    "a/x",
+    "a/z"
   ]
 }

--- a/test/pause-resume-end-deep.js
+++ b/test/pause-resume-end-deep.js
@@ -1,0 +1,67 @@
+// pause-resume-end test
+// show 'end' event is emitted properly
+require("./global-leakage.js")
+var tap = require("tap")
+var child_process = require("child_process")
+var bashResults = require("./bash-results.json")
+var globs = Object.keys(bashResults)
+var glob = require("../")
+var path = require("path")
+
+// run from the root of the project
+// this is usually where you're at anyway, but be sure.
+var root = path.dirname(__dirname)
+var fixtures = path.resolve(__dirname, 'fixtures')
+process.chdir(fixtures)
+
+
+
+function alphasort (a, b) {
+  a = a.toLowerCase()
+  b = b.toLowerCase()
+  return a > b ? 1 : a < b ? -1 : 0
+}
+
+globs.forEach(function (pattern) {
+  var expect = bashResults[pattern]
+  // anything regarding the symlink thing will fail on windows, so just skip it
+  if (process.platform === "win32" &&
+      expect.some(function (m) {
+        return /\bsymlink\b/.test(m)
+      }))
+    return
+
+  tap.test(pattern + " reaches end correctly when pause/resume", function (t) {
+    var g = new glob.Glob(pattern, function (er, matches) {
+      if (er)
+        throw er
+
+      // sort and unmark, just to match the shell results
+      matches = cleanResults(matches)
+      t.deepEqual(matches, expect, pattern) //deep detect if end yields expected matches
+
+      t.end()
+    })
+    .on('match',function(m) {
+
+      //pause and then resume after every match
+      g.pause()
+      setTimeout(g.resume.bind(g), 10)
+    })
+  })
+})
+
+function cleanResults (m) {
+  // normalize discrepancies in ordering, duplication,
+  // and ending slashes.
+  return m.map(function (m) {
+    return m.replace(/\/+/g, "/").replace(/\/$/, "")
+  }).sort(alphasort).reduce(function (set, f) {
+    if (f !== set[set.length - 1]) set.push(f)
+    return set
+  }, []).map(function (f) {
+    // de-windows
+    return (process.platform !== 'win32') ? f
+           : f.replace(/^[a-zA-Z]:[\/\\]+/, '/').replace(/[\\\/]+/g, '/')
+  }).sort(alphasort)
+}

--- a/test/pause-resume-end-shallow.js
+++ b/test/pause-resume-end-shallow.js
@@ -1,0 +1,42 @@
+// pause-resume-end test
+// show 'end' event is emitted properly
+require("./global-leakage.js")
+
+var tap = require("tap")
+var bashResults = require("./bash-results.json")
+var globs = Object.keys(bashResults)
+var glob = require("../")
+var Glob = glob.Glob
+
+process.chdir(__dirname + '/fixtures')
+
+globs.forEach(function (pattern) {
+  var expect = bashResults[pattern]
+
+  if (process.platform === "win32" &&
+      expect.some(function (m) {
+        return /\bsymlink\b/.test(m)
+      }))
+    return
+
+  tap.test(pattern + " reaches end correctly when pause/resume", function (t) {
+
+    var g = new glob.Glob(pattern)
+    g.on("match", function (m) {
+      //pause and then resume after every match
+      g.pause()
+      setTimeout(g.resume.bind(g), 10)
+    })
+
+    g.on("end", function (matches) {
+      if(matches.length == expect.length) { //shallow detect if end yields expected matches
+        t.pass("reached glob end after matching completed")
+        t.end()
+      }else if(matches.length < expect.length) {  //ensure if end yields less than expected matches
+        g.abort();
+        t.fail("reached glob end before matching completed")
+        t.end()
+      }
+    })
+  })
+})


### PR DESCRIPTION
- addressing #323 
- adds two new test patterns: a/\*, a/\*/\*\*
- includes two variants of the test, using deep and shallow result
comparison
- the deep variant shows when 'end' misfires