### PR TITLE
made the explanation of {..} more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,13 @@ glob("**/*.js", options, function (er, files) {
 "Globs" are the patterns you type when you do stuff like `ls *.js` on
 the command line, or put `build/*` in a `.gitignore` file.
 
-Before parsing the path part patterns, braced sections are expanded
-into a set.  Braced sections start with `{` and end with `}`, with any
-number of comma-delimited sections within.  Braced sections may contain
-slash characters, so `a{/b/c,bcd}` would expand into `a/b/c` and `abcd`.
-
 The following characters have special magic meaning when used in a
 path portion:
 
+* `{...}` Before parsing the path part patterns, braced sections are expanded
+into a set.  Braced sections start with `{` and end with `}`, with any
+number of comma-delimited sections within.  Braced sections may contain
+slash characters, so `a{/b/c,bcd}` would expand into `a/b/c` and `abcd`.
 * `*` Matches 0 or more characters in a single path portion
 * `?` Matches 1 character
 * `[...]` Matches a range of characters, similar to a RegExp range.


### PR DESCRIPTION
I had tried to read this README three times trying to find the explanation for `{...}` in glob patterns before going "I can't find it" and filing an issue on a repo that used them to ask what they did, only for someone to point me straight back at the repo telling me they too couldn't initially find it because it looks like introduction text, but that it was in there.

Reading is one of those skills you assume everyone has, and it's easy to not even consider that not everyone untangles information equally efficient, so this change makes it far more likely that readers looking for the syntax explanation will flag the text covering the `{...}` syntax as a proper explanation, rather than as part of the section's intro text that their brain refuses to parse as the information they need.