### PR TITLE
Add option to cache lstat results instead of stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ the filesystem.
   to set this, you may pass the statCache from one glob() call to the
   options object of another, if you know that the filesystem will not
   change between calls.  (See "Race Conditions" below.)
+* `noresolve` Set to true to cache the result of `lstat` (instead of
+  `stat`) when matching symlinks.
 * `symlinks` A cache of known symbolic links.  You may pass in a
   previously generated `symlinks` object to save `lstat` calls when
   resolving `**` matches.

--- a/common.js
+++ b/common.js
@@ -85,6 +85,7 @@ function setopts (self, pattern, options) {
   self.maxLength = options.maxLength || Infinity
   self.cache = options.cache || Object.create(null)
   self.statCache = options.statCache || Object.create(null)
+  self.noresolve = !!options.noresolve
   self.symlinks = options.symlinks || Object.create(null)
 
   setupIgnores(self, options)

--- a/glob.js
+++ b/glob.js
@@ -751,7 +751,7 @@ Glob.prototype._stat = function (f, cb) {
     fs.lstat(abs, statcb)
 
   function lstatcb_ (er, lstat) {
-    if (lstat && lstat.isSymbolicLink()) {
+    if (lstat && lstat.isSymbolicLink() && !self.noresolve) {
       // If it's a symlink, then treat it as the target, unless
       // the target does not exist, then treat it as a file.
       return fs.stat(abs, function (er, stat) {

--- a/sync.js
+++ b/sync.js
@@ -452,7 +452,7 @@ GlobSync.prototype._stat = function (f) {
       }
     }
 
-    if (lstat && lstat.isSymbolicLink()) {
+    if (lstat && lstat.isSymbolicLink() && !this.noresolve) {
       try {
         stat = fs.statSync(abs)
       } catch (er) {

--- a/test/eperm-stat.js
+++ b/test/eperm-stat.js
@@ -87,6 +87,11 @@ t.test('globstar with error in root', function (t) {
     'a/x',
     'a/z'
   ]
+  if (process.platform === 'win32') {
+    expect = expect.filter(function(path) {
+      return path.indexOf('/symlink') === -1
+    })
+  }
 
   var pattern = 'a/**'
   t.plan(2)

--- a/test/noresolve.js
+++ b/test/noresolve.js
@@ -1,0 +1,30 @@
+require("./global-leakage.js")
+
+if (process.platform === "win32")
+    return
+
+var glob = require('../')
+var test = require('tap').test
+var Stats = require('fs').Stats
+var dir = __dirname + '/fixtures'
+
+test('noresolve async', function(t) {
+  var g = new glob.Glob('a/symlink/a/b/c', { stat: true, cwd: dir, noresolve: true })
+  g.on('stat', function(m, st) {
+    t.ok(st instanceof Stats)
+    t.ok(st.isSymbolicLink())
+  })
+  g.on('end', function(eof) {
+    t.end()
+  })
+})
+
+test('noresolve sync', function(t) {
+  var g = new glob.GlobSync('a/symlink/a/b/c', { stat: true, cwd: dir, noresolve: true })
+  Object.keys(g.statCache).forEach(function(k) {
+    var st = g.statCache[k]
+    t.ok(st instanceof Stats)
+    t.ok(st.isSymbolicLink())
+  });
+  t.end()
+})


### PR DESCRIPTION
I'm preparing a PR to vinyl-fs to signifcantly reduce the number of fs operations by leveraging node-glob's caches. However there's a `resolveSymlinks` option which users set to false to obtain stats of the link, rather than the target, for symlink matches.

Currently this has us do three stats (an lstat and stat in node-glob, and then another lstat in vinyl-fs). This PR, or something like it, would allow me to reduce that to just one (lstat).

PS I've included a commit from another [PR](https://github.com/isaacs/node-glob/pull/303) to make Appveyor pass.