### PR TITLE
Add support for UNC paths

### DIFF
--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -8,6 +8,7 @@ var i = 0
 var tap = require("tap")
 var fs = require("fs")
 var rimraf = require("rimraf")
+var spawn = require('child_process').spawn
 
 var fixtureDir = path.resolve(__dirname, 'fixtures')
 
@@ -76,13 +77,25 @@ if (process.platform !== "win32") {
   })
 })
 
+// share 'a' via unc path \\<hostname>\glob-test
+if (process.platform === 'win32') {
+  tap.test('create unc-accessible share', function (t) {
+    var localPath = path.resolve(__dirname, 'fixtures/a')
+    var net = spawn('net', ['share', 'glob-test=' + localPath])
+    net.stderr.pipe(process.stderr)
+    net.on('close', function (code) {
+      t.equal(code, 0, 'failed to create a unc share')
+      t.end()
+    })
+  })
+}
+
 // generate the bash pattern test-fixtures if possible
 if (process.platform === "win32" || !process.env.TEST_REGEN) {
   console.error("Windows, or TEST_REGEN unset.  Using cached fixtures.")
   return
 }
 
-var spawn = require("child_process").spawn;
 var globs =
   // put more patterns here.
   // anything that would be directly in / should be in /tmp/glob-test

--- a/test/windows-tests.js
+++ b/test/windows-tests.js
@@ -1,0 +1,25 @@
+require('./global-leakage.js')
+
+var os = require('os')
+var path = require('path')
+var glob = require('../glob.js')
+var test = require('tap').test
+
+if (process.platform !== 'win32') {
+  console.log('Skipping Windows-specific tests')
+  return
+}
+
+var uncRoot = '\\\\' + os.hostname() + '\\glob-test'
+
+test('glob doesn\'t choke on UNC paths', function(t) {
+  var expect = [uncRoot + '\\c', uncRoot + '\\cb']
+
+  var results = glob(uncRoot + '\\c*', function (er, results) {
+    if (er)
+      throw er
+
+    t.same(results, expect)
+    t.end()
+  })
+})

--- a/test/zz-cleanup.js
+++ b/test/zz-cleanup.js
@@ -3,6 +3,19 @@ require("./global-leakage.js")
 var tap = require("tap")
 , rimraf = require("rimraf")
 , path = require("path")
+, spawn = require('child_process').spawn
+
+// remove unc share
+if (process.platform === 'win32') {
+  tap.test('remove unc-accessible share', function (t) {
+    var net = spawn('net', ['share', 'glob-test', '/y', '/delete'])
+    net.stderr.pipe(process.stderr)
+    net.on('close', function (code) {
+      t.equal(code, 0, 'failed to remove unc share')
+      t.end()
+    })
+  })
+}
 
 tap.test("cleanup fixtures", function (t) {
   rimraf(path.resolve(__dirname, "fixtures"), function (er) {


### PR DESCRIPTION
This adds *nix support for the test in @staticshock's PR #146 (test fails on *nix before the implementation and passes on *nix after the implementation)

The test operates on *nix by mocking out `process.platform` (set to `'win32'`), `minimatch.Minimatch` (to fix differences between slashes) and `path.resolve` (to translate the UNC path to the local mapped path).

This also removes the `nocase` test from #146 because there was not a working implementation, though I hope to be able to add an implementation and test there, too.