### PR TITLE
Match absolute paths on Windows

### DIFF
--- a/common.js
+++ b/common.js
@@ -117,7 +117,7 @@ function setopts (self, pattern, options) {
   if (process.platform === "win32") {
     var winPath = new WinPath(pattern)
     if (winPath.isAbsolute) {
-      options.root = winPath.device
+      options.root = winPath.device + '\\'
       pattern = winPath.sep + winPath.tail
     }
   }

--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -8,6 +8,7 @@ var i = 0
 var tap = require("tap")
 var fs = require("fs")
 var rimraf = require("rimraf")
+var spawn = require('child_process').spawn
 
 var fixtureDir = path.resolve(__dirname, 'fixtures')
 
@@ -76,13 +77,25 @@ if (process.platform !== "win32") {
   })
 })
 
+// share 'a' via unc path \\<hostname>\glob-test
+if (process.platform === 'win32') {
+  tap.test('create unc-accessible share', function (t) {
+    var localPath = path.resolve(__dirname, 'fixtures/a')
+    var net = spawn('net', ['share', 'glob-test=' + localPath])
+    net.stderr.pipe(process.stderr)
+    net.on('close', function (code) {
+      t.equal(code, 0, 'failed to create a unc share')
+      t.end()
+    })
+  })
+}
+
 // generate the bash pattern test-fixtures if possible
 if (process.platform === "win32" || !process.env.TEST_REGEN) {
   console.error("Windows, or TEST_REGEN unset.  Using cached fixtures.")
   return
 }
 
-var spawn = require("child_process").spawn;
 var globs =
   // put more patterns here.
   // anything that would be directly in / should be in /tmp/glob-test

--- a/test/windows-tests.js
+++ b/test/windows-tests.js
@@ -1,0 +1,25 @@
+require('./global-leakage.js')
+
+var os = require('os')
+var path = require('path')
+var glob = require('../glob.js')
+var test = require('tap').test
+
+if (process.platform !== 'win32') {
+  console.log('Skipping Windows-specific tests')
+  return
+}
+
+var uncRoot = '\\\\' + os.hostname() + '\\glob-test'
+
+test('glob doesn\'t choke on UNC paths', function(t) {
+  var expect = [uncRoot + '\\c', uncRoot + '\\cb']
+
+  var results = glob(uncRoot + '\\c*', function (er, results) {
+    if (er)
+      throw er
+
+    t.same(results, expect)
+    t.end()
+  })
+})

--- a/test/windows-tests.js
+++ b/test/windows-tests.js
@@ -63,3 +63,11 @@ test('glob doesn\'t choke on UNC paths', function(t) {
     t.end()
   })
 })
+
+test('can match abs paths on Windows with nocase', function(t) {
+  var testPath = path.resolve(__dirname, "a")
+  glob(testPath, {nocase: true}, function (err, match) {
+    t.same(match, [testPath])
+    t.end()
+  })
+})

--- a/test/windows-tests.js
+++ b/test/windows-tests.js
@@ -4,6 +4,7 @@ var os = require('os')
 
 var uncRoot = '\\\\' + os.hostname() + '\\glob-test'
 var localRoot = path.resolve(__dirname, 'fixtures/a')
+var windowsRoot = localRoot
 
 function mockMinimatchForWin32() {
   var minimatch = require('minimatch')
@@ -32,6 +33,8 @@ function mockResolveForWin32() {
     var args = arguments
     if (args[0].indexOf(uncRoot) === 0) {
       args[0] = args[0].replace(uncRoot, localRoot).replace(/\\/g, '/')
+    } else if (args[0].indexOf('C:\\') === 0) {
+      args[0] = args[0].replace('C:\\', '/').replace(/\\/g, '/')
     }
     return originalResolve.apply(path, args)
   }
@@ -43,6 +46,7 @@ function mockProcessPlatformForWin32() {
 
 var mockingWin32 = process.platform !== 'win32'
 if (mockingWin32) {
+  windowsRoot = 'C:' + localRoot.replace(/\//g, '\\')
   mockMinimatchForWin32()
   mockResolveForWin32()
 }
@@ -65,8 +69,8 @@ test('glob doesn\'t choke on UNC paths', function(t) {
 })
 
 test('can match abs paths on Windows with nocase', function(t) {
-  var testPath = path.resolve(__dirname, "a")
-  glob(testPath, {nocase: true}, function (err, match) {
+  var testPath = path.resolve(__dirname, "fixtures/a/b/c/d")
+  glob(windowsRoot + '\\**\\b\\c\\d', {nocase: true}, function (err, match) {
     t.same(match, [testPath])
     t.end()
   })

--- a/test/zz-cleanup.js
+++ b/test/zz-cleanup.js
@@ -3,6 +3,19 @@ require("./global-leakage.js")
 var tap = require("tap")
 , rimraf = require("rimraf")
 , path = require("path")
+, spawn = require('child_process').spawn
+
+// remove unc share
+if (process.platform === 'win32') {
+  tap.test('remove unc-accessible share', function (t) {
+    var net = spawn('net', ['share', 'glob-test', '/y', '/delete'])
+    net.stderr.pipe(process.stderr)
+    net.on('close', function (code) {
+      t.equal(code, 0, 'failed to remove unc share')
+      t.end()
+    })
+  })
+}
 
 tap.test("cleanup fixtures", function (t) {
   rimraf(path.resolve(__dirname, "fixtures"), function (er) {


### PR DESCRIPTION
This fixes a bug on Windows where `root` is mishandled and so it is impossible to match absolute paths.  This PR depends on #345.

Fixes #290 