### PR TITLE
Fix ENOTDIR error in sync.js when reading directories

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -283,6 +283,10 @@ GlobSync.prototype._readdir = function (abs, inGlobStar) {
     if (Array.isArray(c))
       return c
   }
+  
+  if(fs.existsSync(abs) && !fs.lstatSync(abs).isDirectory()) {
+    return null;
+  }
 
   try {
     return this._readdirEntries(abs, fs.readdirSync(abs))


### PR DESCRIPTION
This was causing an issue for me on Ubuntu 16.04 with NVM and Node 8.10 when running `yo`.