### PR TITLE
Fix documentation for synchronous functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ Perform an asynchronous glob search.
 
   :warning: Must include property `sync: true` to run synchronously.
 
-* return: `{Object}`
-  * `matches` `{Array<String>}` Array of matched filenames
+* return: `{Array<String>}` Array of matched filenames
 
 Perform a synchronous glob search.
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,15 @@ options.
 
 Perform an asynchronous glob search.
 
-## glob.sync(pattern, [options])
+## glob.sync(pattern, options)
 
 * `pattern` `{String}` Pattern to be matched
 * `options` `{Object}`
-* return: `{Array<String>}` filenames found matching the pattern
+
+  :warning: Must include property `sync: true` to run synchronously.
+
+* return: `{Object}`
+  * `matches` `{Array<String>}` Array of matched filenames
 
 Perform a synchronous glob search.
 


### PR DESCRIPTION
Because the user cannot merely remove the callback function for the blog to be done synchronously. What *actually* makes it run synchronously is setting `sync: true` in `options`.