### PR TITLE
chore: Remove nested FUNDING.yml

### DIFF
--- a/.github/.github/FUNDING.yml
+++ b/.github/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: [isaacs]


### PR DESCRIPTION
Looks like a second FUNDING was adding in an additional `.github` folder by accident