### PR TITLE
Provide a custom fs module option

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,31 @@ the filesystem.
 * `absolute` Set to true to always receive absolute paths for matched
   files.  Unlike `realpath`, this also affects the values returned in
   the `match` event.
+* `fs` To provide a custom `fs` module like the in-memory file-system [memfs](https://github.com/streamich/memfs) often used for testing.
+  Example:
+  ```js
+  var glob = require("glob");
+  var vol = require("memfs").vol;
+
+  const json = {
+    "./README.md": "1",
+    "./src/index.js": "2",
+    "./node_modules/debug/index.js": "3",
+  };
+  vol.fromJSON(json, "/app");
+
+  var opt = {
+    cwd: "/app",
+    fs: vol,
+  };
+
+  glob("**/*.js", opt, function (er, files) {
+    if (er) {
+      console.log(er);
+    }
+    console.log(files);
+  });
+  ```
 
 ## Comparisons to other fnmatch/glob implementations
 

--- a/glob.js
+++ b/glob.js
@@ -123,6 +123,10 @@ function Glob (pattern, options, cb) {
     options = null
   }
 
+  if (options && options.fs) {
+    fs = options.fs
+  }
+
   if (options && options.sync) {
     if (cb)
       throw new TypeError('callback provided to sync glob')


### PR DESCRIPTION
To provide a custom `fs` module like the in-memory file-system [memfs](https://github.com/streamich/memfs) often used for testing.
  Example:
  ```js
  var glob = require("glob");
  var vol = require("memfs").vol;
  const json = {
    "./README.md": "1",
    "./src/index.js": "2",
    "./node_modules/debug/index.js": "3",
  };
  vol.fromJSON(json, "/app");
  var opt = {
    cwd: "/app",
    fs: vol,
  };
  glob("**/*.js", opt, function (er, files) {
    if (er) {
      console.log(er);
    }
    console.log(files);
  });
  ```