### PR TITLE
chore: drop path-is-absolute

### DIFF
--- a/common.js
+++ b/common.js
@@ -13,7 +13,6 @@ function ownProp (obj, field) {
 var fs = require("fs")
 var path = require("path")
 var minimatch = require("minimatch")
-var isAbsolute = require("path-is-absolute")
 var Minimatch = minimatch.Minimatch
 
 function alphasort (a, b) {
@@ -101,7 +100,7 @@ function setopts (self, pattern, options) {
 
   // TODO: is an absolute `cwd` supposed to be resolved against `root`?
   // e.g. { cwd: '/test', root: __dirname } === path.join(__dirname, '/test')
-  self.cwdAbs = isAbsolute(self.cwd) ? self.cwd : makeAbs(self, self.cwd)
+  self.cwdAbs = path.isAbsolute(self.cwd) ? self.cwd : makeAbs(self, self.cwd)
   if (process.platform === "win32")
     self.cwdAbs = self.cwdAbs.replace(/\\/g, "/")
   self.nomount = !!options.nomount
@@ -200,7 +199,7 @@ function makeAbs (self, f) {
   var abs = f
   if (f.charAt(0) === '/') {
     abs = path.join(self.root, f)
-  } else if (isAbsolute(f) || f === '') {
+  } else if (path.isAbsolute(f) || f === '') {
     abs = f
   } else if (self.changedCwd) {
     abs = path.resolve(self.cwd, f)

--- a/glob.js
+++ b/glob.js
@@ -47,7 +47,6 @@ var inherits = require('inherits')
 var EE = require('events').EventEmitter
 var path = require('path')
 var assert = require('assert')
-var isAbsolute = require('path-is-absolute')
 var globSync = require('./sync.js')
 var common = require('./common.js')
 var setopts = common.setopts
@@ -342,8 +341,8 @@ Glob.prototype._process = function (pattern, index, inGlobStar, cb) {
   var read
   if (prefix === null)
     read = '.'
-  else if (isAbsolute(prefix) || isAbsolute(pattern.join('/'))) {
-    if (!prefix || !isAbsolute(prefix))
+  else if (path.isAbsolute(prefix) || path.isAbsolute(pattern.join('/'))) {
+    if (!prefix || !path.isAbsolute(prefix))
       prefix = '/' + prefix
     read = prefix
   } else
@@ -460,7 +459,7 @@ Glob.prototype._emitMatch = function (index, e) {
     return
   }
 
-  var abs = isAbsolute(e) ? e : this._makeAbs(e)
+  var abs = path.isAbsolute(e) ? e : this._makeAbs(e)
 
   if (this.mark)
     e = this._mark(e)
@@ -684,7 +683,7 @@ Glob.prototype._processSimple2 = function (prefix, index, er, exists, cb) {
   if (!exists)
     return cb()
 
-  if (prefix && isAbsolute(prefix) && !this.nomount) {
+  if (prefix && path.isAbsolute(prefix) && !this.nomount) {
     var trail = /[\/\\]$/.test(prefix)
     if (prefix.charAt(0) === '/') {
       prefix = path.join(this.root, prefix)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "once": "^1.3.0"
       },
       "devDependencies": {
         "memfs": "^3.2.0",
@@ -2031,6 +2030,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6478,7 +6478,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "inflight": "^1.0.4",
     "inherits": "2",
     "minimatch": "^3.0.4",
-    "once": "^1.3.0",
-    "path-is-absolute": "^1.0.0"
+    "once": "^1.3.0"
   },
   "devDependencies": {
     "memfs": "^3.2.0",

--- a/sync.js
+++ b/sync.js
@@ -8,7 +8,6 @@ var Glob = require('./glob.js').Glob
 var util = require('util')
 var path = require('path')
 var assert = require('assert')
-var isAbsolute = require('path-is-absolute')
 var common = require('./common.js')
 var setopts = common.setopts
 var ownProp = common.ownProp
@@ -109,8 +108,8 @@ GlobSync.prototype._process = function (pattern, index, inGlobStar) {
   var read
   if (prefix === null)
     read = '.'
-  else if (isAbsolute(prefix) || isAbsolute(pattern.join('/'))) {
-    if (!prefix || !isAbsolute(prefix))
+  else if (path.isAbsolute(prefix) || path.isAbsolute(pattern.join('/'))) {
+    if (!prefix || !path.isAbsolute(prefix))
       prefix = '/' + prefix
     read = prefix
   } else
@@ -393,7 +392,7 @@ GlobSync.prototype._processSimple = function (prefix, index) {
   if (!exists)
     return
 
-  if (prefix && isAbsolute(prefix) && !this.nomount) {
+  if (prefix && path.isAbsolute(prefix) && !this.nomount) {
     var trail = /[\/\\]$/.test(prefix)
     if (prefix.charAt(0) === '/') {
       prefix = path.join(this.root, prefix)

--- a/test/absolute.js
+++ b/test/absolute.js
@@ -4,12 +4,12 @@ var glob = require('../')
 var common = require('../common.js')
 var pattern = 'a/b/**';
 var bashResults = require('./bash-results.json')
-var isAbsolute = require('path-is-absolute')
+var path = require('path')
 process.chdir(__dirname + '/fixtures')
 
 t.Test.prototype.addAssert('isAbsolute', 1, function (file, message, extra) {
   extra.found = file
-  return this.ok(isAbsolute(file), message || 'must be absolute', extra)
+  return this.ok(path.isAbsolute(file), message || 'must be absolute', extra)
 })
 
 var marks = [ true, false ]
@@ -41,7 +41,7 @@ marks.forEach(function (mark) {
 
       t.equal(results.length, bashResults[pattern].length, 'must match all files')
       results.forEach(function (m) {
-        t.ok(isAbsolute(m), 'must be absolute', { found: m })
+        t.ok(path.isAbsolute(m), 'must be absolute', { found: m })
       })
       t.end()
     })

--- a/test/bash-comparison.js
+++ b/test/bash-comparison.js
@@ -7,7 +7,6 @@ var bashResults = require("./bash-results.json")
 var globs = Object.keys(bashResults)
 var glob = require("../")
 var path = require("path")
-var isAbsolute = require("path-is-absolute")
 
 // run from the root of the project
 // this is usually where you're at anyway, but be sure.
@@ -20,7 +19,7 @@ function cacheCheck(g, t) {
   var caches = [ 'cache', 'statCache', 'symlinks' ]
   caches.forEach(function (c) {
     Object.keys(g[c]).forEach(function (p) {
-      t.ok(isAbsolute(p), p + ' should be absolute')
+      t.ok(path.isAbsolute(p), p + ' should be absolute')
     })
   })
 }

--- a/test/cwd-test.js
+++ b/test/cwd-test.js
@@ -4,7 +4,6 @@ var tap = require("tap")
 var origCwd = process.cwd()
 process.chdir(__dirname + '/fixtures')
 var path = require('path')
-var isAbsolute = require('path-is-absolute')
 var glob = require('../')
 
 function cacheCheck(g, t) {
@@ -12,7 +11,7 @@ function cacheCheck(g, t) {
   var caches = [ 'cache', 'statCache', 'symlinks' ]
   caches.forEach(function (c) {
     Object.keys(g[c]).forEach(function (p) {
-      t.ok(isAbsolute(p), p + ' should be absolute')
+      t.ok(path.isAbsolute(p), p + ' should be absolute')
     })
   })
 }

--- a/test/nodir.js
+++ b/test/nodir.js
@@ -2,7 +2,6 @@ require("./global-leakage.js")
 var test = require("tap").test
 var glob = require('../')
 var path = require('path')
-var isAbsolute = require('path-is-absolute')
 process.chdir(__dirname + '/fixtures')
 
 function cacheCheck(g, t) {
@@ -10,7 +9,7 @@ function cacheCheck(g, t) {
   var caches = [ 'cache', 'statCache', 'symlinks' ]
   caches.forEach(function (c) {
     Object.keys(g[c]).forEach(function (p) {
-      t.ok(isAbsolute(p), p + ' should be absolute')
+      t.ok(path.isAbsolute(p), p + ' should be absolute')
     })
   })
 }

--- a/test/root-nomount.js
+++ b/test/root-nomount.js
@@ -2,14 +2,13 @@ require("./global-leakage.js")
 var tap = require("tap")
 var glob = require('../')
 var path = require('path')
-var isAbsolute = require('path-is-absolute')
 
 function cacheCheck(g, t) {
   // verify that path cache keys are all absolute
   var caches = [ 'cache', 'statCache', 'symlinks' ]
   caches.forEach(function (c) {
     Object.keys(g[c]).forEach(function (p) {
-      t.ok(isAbsolute(p), p + ' should be absolute')
+      t.ok(path.isAbsolute(p), p + ' should be absolute')
     })
   })
 }

--- a/test/root.js
+++ b/test/root.js
@@ -5,14 +5,13 @@ process.chdir(__dirname + '/fixtures')
 
 var glob = require('../')
 var path = require('path')
-var isAbsolute = require('path-is-absolute')
 
 function cacheCheck(g, t) {
   // verify that path cache keys are all absolute
   var caches = [ 'cache', 'statCache', 'symlinks' ]
   caches.forEach(function (c) {
     Object.keys(g[c]).forEach(function (p) {
-      t.ok(isAbsolute(p), p + ' should be absolute')
+      t.ok(path.isAbsolute(p), p + ' should be absolute')
     })
   })
 }


### PR DESCRIPTION
Node has supported `path.isAbsolute` since before 1.x as far as i remember.

maybe now is finally the time to use the native functionality?