### PR TITLE
[Refactor] use more explicit `assert.ok`

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -48,7 +48,7 @@ function GlobSync (pattern, options) {
 }
 
 GlobSync.prototype._finish = function () {
-  assert(this instanceof GlobSync)
+  assert.ok(this instanceof GlobSync)
   if (this.realpath) {
     var self = this
     this.matches.forEach(function (matchset, index) {
@@ -72,7 +72,7 @@ GlobSync.prototype._finish = function () {
 
 
 GlobSync.prototype._process = function (pattern, index, inGlobStar) {
-  assert(this instanceof GlobSync)
+  assert.ok(this instanceof GlobSync)
 
   // Get the first [n] parts of pattern that are all strings.
   var n = 0


### PR DESCRIPTION
This is a tiny refactor, hopefully it's acceptable.

(We'll all be much happier if you choose not to ask why i need this change :-) )