### PR TITLE
always coerce cwd, root to '/' separated paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
         run: npm install
 
       - name: Run Tests
-        run: npm test -- -c -t0
+        run: npm test -- -c -t0 --statements=80 --branches=80 --functions=80 --lines=80

--- a/common.js
+++ b/common.js
@@ -88,7 +88,7 @@ function setopts (self, pattern, options) {
   self.changedCwd = false
   var cwd = process.cwd()
   if (!ownProp(options, "cwd"))
-    self.cwd = cwd
+    self.cwd = path.resolve(cwd)
   else {
     self.cwd = path.resolve(options.cwd)
     self.changedCwd = self.cwd !== cwd
@@ -96,15 +96,17 @@ function setopts (self, pattern, options) {
 
   self.root = options.root || path.resolve(self.cwd, "/")
   self.root = path.resolve(self.root)
-  if (process.platform === "win32")
-    self.root = self.root.replace(/\\/g, "/")
 
   // TODO: is an absolute `cwd` supposed to be resolved against `root`?
   // e.g. { cwd: '/test', root: __dirname } === path.join(__dirname, '/test')
   self.cwdAbs = isAbsolute(self.cwd) ? self.cwd : makeAbs(self, self.cwd)
-  if (process.platform === "win32")
-    self.cwdAbs = self.cwdAbs.replace(/\\/g, "/")
   self.nomount = !!options.nomount
+
+  if (process.platform === "win32") {
+    self.root = self.root.replace(/\\/g, "/")
+    self.cwd = self.cwd.replace(/\\/g, "/")
+    self.cwdAbs = self.cwdAbs.replace(/\\/g, "/")
+  }
 
   // disable comments and negation in Minimatch.
   // Note that they are not supported in Glob itself anyway.

--- a/test/cwd-test.js
+++ b/test/cwd-test.js
@@ -69,7 +69,7 @@ tap.test("changing cwd and searching for **/d", function (t) {
 tap.test('non-dir cwd should raise error', function (t) {
   var notdir = 'a/b/c/d'
   var notdirRE = /a[\\\/]b[\\\/]c[\\\/]d/
-  var abs = path.resolve(notdir)
+  var abs = path.resolve(notdir).split('\\').join('/')
   var expect = new Error('ENOTDIR invalid cwd ' + abs)
   expect.code = 'ENOTDIR'
   expect.path = notdirRE


### PR DESCRIPTION
Re: https://github.com/isaacs/node-glob/issues/467