### PR TITLE
fix: disable allowWindowsEscape on minimatch

### DIFF
--- a/common.js
+++ b/common.js
@@ -110,8 +110,6 @@ function setopts (self, pattern, options) {
   // Note that they are not supported in Glob itself anyway.
   options.nonegate = true
   options.nocomment = true
-  // always treat \ in patterns as escapes, not path separators
-  options.allowWindowsEscape = true
 
   self.minimatch = new Minimatch(pattern, options)
   self.options = self.minimatch.options


### PR DESCRIPTION
This fixes #471 by a partial revert of 73feafd17f1c04633349652605e12fbbaef9b3cf.
See my comment on the issue https://github.com/isaacs/node-glob/issues/471#issuecomment-1126739067 for more details.

I intend for this to be released as a patch to only v7.