### PR TITLE
feat: add pathsep option

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ the filesystem.
 * `symlinks` A cache of known symbolic links.  You may pass in a
   previously generated `symlinks` object to save `lstat` calls when
   resolving `**` matches.
+* `pathsep` The separator used in the pattern. Setting this to the
+  literal character `\` will result in unexpected behavior when escaping
+  literal glob characters.
 * `sync` DEPRECATED: use `glob.sync(pattern, opts)` instead.
 * `nounique` In some cases, brace-expanded patterns can result in the
   same file showing up multiple times in the result set.  By default,
@@ -331,6 +334,10 @@ be interpreted as escape characters, not path separators.
 Results from absolute patterns such as `/foo/*` are mounted onto the
 root setting using `path.join`.  On windows, this will by default result
 in `/foo/*` matching `C:\foo\bar.txt`.
+
+To have glob coerce the separator used in pattern strings to `/`, **thus
+making it impossible to use the separator to escape literal glob characters**,
+you may set the `pathSep` option to the separator used.
 
 ## Race Conditions
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 8.1
+
+- Add `pathsep` option
+
 ## 8.0
 
 - Only support node v12 and higher

--- a/common.js
+++ b/common.js
@@ -83,6 +83,11 @@ function setopts (self, pattern, options) {
   self.statCache = options.statCache || Object.create(null)
   self.symlinks = options.symlinks || Object.create(null)
 
+  // avoiding empty strings
+  if (!!options.pathsep) {
+    pattern = pattern.split(options.pathsep).join("/")
+  }
+
   setupIgnores(self, options)
 
   self.changedCwd = false

--- a/test/path-sep.js
+++ b/test/path-sep.js
@@ -1,0 +1,30 @@
+require("./global-leakage.js")
+var t = require("tap")
+var glob = require("../")
+var bashResults = require("./bash-results.json")
+process.chdir(__dirname + "/fixtures")
+
+var processedResults = Object.keys(bashResults).reduce(
+  (acc, val) => [...acc, [val, glob.sync(val)]],
+  []
+)
+
+;["/", "\\", "<>", "sep"].forEach((sep) => {
+  processedResults.forEach(([originalPattern, expectedResults]) => {
+    var pattern = originalPattern.split("/").join(sep)
+
+    glob(pattern, { pathsep: sep }, (err, matches) => {
+      if (err) t.fail(err.message)
+
+      // testing symlinks is completely unpredictable cross-platform, remove everything to do with symlinks
+      matches = matches.filter((val) => !val.includes("symlink"))
+      expectedResults = expectedResults.filter((val) => !val.includes("symlink"))
+
+      t.strictSame(
+        matches.sort(),
+        expectedResults.sort(),
+        `${originalPattern} matches with separator ${sep}`
+      )
+    })
+  })
+})


### PR DESCRIPTION
This is the first part of the implementation of #468. This PR implements the pathsep option, which is intended to allow users to specify the path separator used in the glob pattern.