### PR TITLE
feat: add supportWindowsPaths option

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ the filesystem.
   to set this, you may pass the statCache from one glob() call to the
   options object of another, if you know that the filesystem will not
   change between calls.  (See "Race Conditions" below.)
+* `supportWindowsPaths` Supports both `/` and `\` as path separators.
+  Because the option replaces backslashes with forward slashes, any
+  escaped literal glob characters will result in unexpected behavior.
 * `symlinks` A cache of known symbolic links.  You may pass in a
   previously generated `symlinks` object to save `lstat` calls when
   resolving `**` matches.
@@ -331,6 +334,11 @@ be interpreted as escape characters, not path separators.
 Results from absolute patterns such as `/foo/*` are mounted onto the
 root setting using `path.join`.  On windows, this will by default result
 in `/foo/*` matching `C:\foo\bar.txt`.
+
+Alternatively, you may set the `supportWindowsPaths` option to make glob
+coerce backslashes to forward slashes. Keep in mind that
+`supportWindowsPaths` will result in unexpected behavior when escaping
+literal glob characters.
 
 ## Race Conditions
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 8.1
+
+- Add `supportWindowsPaths` option
+
 ## 8.0
 
 - Only support node v12 and higher

--- a/common.js
+++ b/common.js
@@ -68,6 +68,11 @@ function setopts (self, pattern, options) {
   self.nodir = !!options.nodir
   if (self.nodir)
     self.mark = true
+  self.supportWindowsPaths = !!options.supportWindowsPaths
+  if (self.supportWindowsPaths) {
+    options.pathSep = undefined
+    pattern = pattern.replace(/\\/g, "/")
+  }
   self.sync = !!options.sync
   self.nounique = !!options.nounique
   self.nonull = !!options.nonull

--- a/test/support-windows-paths.js
+++ b/test/support-windows-paths.js
@@ -1,0 +1,61 @@
+require('./global-leakage.js')
+var test = require('tap').test
+var glob = require('../')
+var bashResults = require('./bash-results.json')
+process.chdir(__dirname + '/fixtures')
+
+var processedResults = Object.keys(bashResults).reduce(
+  (acc, val) =>
+    !val.includes('symlink')
+      ? [
+          ...acc,
+          [val, glob.sync(val).filter((val) => !val.includes('symlink'))],
+        ]
+      : acc,
+  []
+)
+
+var bothSlashes = '\\/'
+
+function forEachSlashPattern(originalPattern, cb) {
+  for (var slashPattern of ['/', '\\', bothSlashes]) {
+    var newPattern = originalPattern
+    if (slashPattern === bothSlashes) {
+      const patternParts = originalPattern.split('/')
+      newPattern = ''
+
+      patternParts.forEach((val, valIndexInArr, { length: arrLength }) => {
+        newPattern += val
+        // arrLength is one plus the index of the last element
+        // using return since there will be no more iterations to go through if the expression is true
+        if (valIndexInArr === arrLength - 1) return
+        // the separators should always alternate between forward and backward slashes
+        newPattern += valIndexInArr % 2 === 0 ? '/' : '\\'
+      })
+    } else {
+      newPattern = originalPattern.split('/').join(slashPattern)
+    }
+
+    cb(newPattern, slashPattern)
+  }
+}
+
+// testing symlinks is outside of the scope of this test
+test('support windows paths as a config option', (t) => {
+  processedResults.forEach(([originalPattern, expectedResults]) => {
+    forEachSlashPattern(originalPattern, (pattern, slashPattern) => {
+      t.strictSame(
+        glob.sync(pattern, { supportWindowsPaths: true })
+          .filter((val) => !val.includes('symlink'))
+          .sort(),
+        expectedResults.sort(),
+        `${originalPattern} correctly evaluates with ${
+          slashPattern === bothSlashes
+            ? 'both separators'
+            : `${slashPattern} separator`
+        }, pattern is ${pattern}`
+      )
+    })
+  })
+  t.end()
+})


### PR DESCRIPTION
This is the second and last part of the implementation of #468. The PR implements the supportWindowsPaths option, which is intended to be a flip-on switch for automatic backslash coercion.

closes #468