### PR TITLE
Remove dependency on path-is-absolute

### DIFF
--- a/test/nodir.js
+++ b/test/nodir.js
@@ -2,7 +2,6 @@ require("./global-leakage.js")
 var test = require("tap").test
 var glob = require('../')
 var path = require('path')
-var isAbsolute = require('path-is-absolute')
 process.chdir(__dirname + '/fixtures')
 
 function cacheCheck(g, t) {
@@ -10,7 +9,7 @@ function cacheCheck(g, t) {
   var caches = [ 'cache', 'statCache', 'symlinks' ]
   caches.forEach(function (c) {
     Object.keys(g[c]).forEach(function (p) {
-      t.ok(isAbsolute(p), p + ' should be absolute')
+      t.ok(path.isAbsolute(p), p + ' should be absolute')
     })
   })
 }

--- a/test/root-nomount.js
+++ b/test/root-nomount.js
@@ -2,14 +2,13 @@ require("./global-leakage.js")
 var tap = require("tap")
 var glob = require('../')
 var path = require('path')
-var isAbsolute = require('path-is-absolute')
 
 function cacheCheck(g, t) {
   // verify that path cache keys are all absolute
   var caches = [ 'cache', 'statCache', 'symlinks' ]
   caches.forEach(function (c) {
     Object.keys(g[c]).forEach(function (p) {
-      t.ok(isAbsolute(p), p + ' should be absolute')
+      t.ok(path.isAbsolute(p), p + ' should be absolute')
     })
   })
 }

--- a/test/root.js
+++ b/test/root.js
@@ -5,14 +5,13 @@ process.chdir(__dirname + '/fixtures')
 
 var glob = require('../')
 var path = require('path')
-var isAbsolute = require('path-is-absolute')
 
 function cacheCheck(g, t) {
   // verify that path cache keys are all absolute
   var caches = [ 'cache', 'statCache', 'symlinks' ]
   caches.forEach(function (c) {
     Object.keys(g[c]).forEach(function (p) {
-      t.ok(isAbsolute(p), p + ' should be absolute')
+      t.ok(path.isAbsolute(p), p + ' should be absolute')
     })
   })
 }


### PR DESCRIPTION
Per https://www.npmjs.com/package/path-is-absolute:

> This package is no longer relevant as Node.js 0.12 is unmaintained.

Note: I didn't see `path-is-absolute` in package.json, but it is listed in package-lock.json. I wasn't sure how to appropriately update package-lock.json without impacting other package versions, so I left it alone. I'd appreciate advice on how to update package-lock.json.