### PR TITLE
Add subpath entry points + CommonJS types fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,14 @@
         "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
+    },
+    "./*.js": {
+      "import": "./dist/mjs/*.js",
+      "require": "./dist/cjs/*.js"
+    },
+    "./*": {
+      "import": "./dist/mjs/*.js",
+      "require": "./dist/cjs/*.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "default": "./dist/mjs/index.js"
       },
       "require": {
-        "types": "./dist/cjs/index-cjs.d.ts",
+        "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
     }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "declaration": true,
+    "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",


### PR DESCRIPTION
Hello 👋 

We're using JSDoc types in CommonJS and looked like the [**types** `"require"` entry got left behind](https://github.com/colinrotherham/node-glob/commit/5f21b46bc21c27ce39e166c064455d8f1ed62863#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19) recently?

* https://github.com/alphagov/govuk-frontend/pull/3351

I've added a fix and included a few other things:

## CommonJS types

The **types** `"require"` entry doesn't export types `GlobOptions`, `Result`, `Results` etc

```patch
       "require": {
-        "types": "./dist/cjs/index-cjs.d.ts",
+        "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
```

This fixes type declarations in CommonJS such as:

```cjs
/**
 * @param {import('glob').GlobOptions} [options] - Glob options
 */
```

## Subpath package exports

I've added both `"./*.js"` (extensionless) and `"./*"` subpath exports to enable:

### ES modules
```mjs
import { hasMagic } from 'glob/has-magic.js'
```

### CommonJS modules

```cjs
const { hasMagic } = require('glob/has-magic')
```

But also in JSDoc comments:

```cjs
/**
 * @param {import('glob/pattern').GlobList} globList - Glob list
 */
```

## Declaration maps

The compiler option [`{ "declarationMap": true }`](https://www.typescriptlang.org/tsconfig#declarationMap) lets "Go to definition" jump to the TypeScript source