### PR TITLE
chore: use setup-node caching with npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run Tests
         run: npm test -- -c -t0 --statements=80 --branches=80 --functions=80 --lines=80

--- a/.github/workflows/isaacs-makework.yml
+++ b/.github/workflows/isaacs-makework.yml
@@ -14,9 +14,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Use Node.js
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: npm
       - name: put repo in package.json
         run: node .github/workflows/package-json-repo.js
       - name: check in package.json if modified

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -34,8 +34,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Generate typedocs
         run: npm run typedoc
 


### PR DESCRIPTION
Since the actions are using the newer versions of setup-node, they can use the built-in caching of the NPM packages. Also swapped the install for the `ci` so it uses the package-lock.json versions that should match what will be cached