### PR TITLE
ci: test on Node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,11 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 19.x]
+        node-version:
+          - 14
+          - 16
+          - 18
+          - 19
         platform:
         - os: ubuntu-latest
           shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,5 @@ jobs:
 
       - name: Run Tests
         run: npm test -- -c -t0 --statements=80 --branches=80 --functions=80 --lines=80
+        env:
+         NODE_OPTIONS: '--experimental-abortcontroller' # Only for Node 14 compat


### PR DESCRIPTION
Although it hits EOL on 2023-04-30, I noticed it was still declared as a supported version in the `engines` so thought it made sense to still have it in the CI till it gets dropped