### PR TITLE
Update globSync documentation to match signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Returns
 objects if the `withFileTypes` option is set to `true`. See below
 for full options field desciptions.
 
-## `globSync(pattern: string, options?: GlobOptions) => string[] | Path[]`
+## `globSync(pattern: string | string[], options?: GlobOptions) => string[] | Path[]`
 
 Synchronous form of `glob()`.
 


### PR DESCRIPTION
I noticed that `globSync` can also accept an array of strings:

https://github.com/isaacs/node-glob/blob/fa8ed5e7986ee3b29e1b437f895fbf3255f0d549/src/index.ts#L71-L74

This just updates the function signature shown in the Readme to match the code.