### PR TITLE
(doc) Switch http to https in blog.izs.me reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
+  "author": "Isaac Z. Schlueter <i@izs.me> (https://blog.izs.me/)",
   "name": "glob",
   "description": "the most correct and second fastest glob implementation in JavaScript",
   "version": "10.2.4",


### PR DESCRIPTION
This PR changes http://blog.izs.me/ to https://blog.izs.me/ in the package author field. HTTPS is supported by the end point, and this shouldn't have any impact to the use of the package.