### PR TITLE
test for out of memory problem with complex glob

### DIFF
--- a/test/oom.ts
+++ b/test/oom.ts
@@ -1,0 +1,18 @@
+import t from 'tap'
+import { Glob } from '../'
+
+const pattern =
+  '@font-face{font-display:var(--fontsource-display,swap);font-family:Poppins;font-style:normal;font-weight:100;src:url(*) format("woff2"),url(*) format("woff")}@font-face{font-display:var(--fontsource-display,swap);font-family:Poppins;font-style:normal;font-weight:200;src:url(*) format("woff2"),url(*) format("woff")}@font-face{font-display:var(--fontsource-display,swap);font-family:Poppins;font-style:normal;font-weight:300;src:url(*) format("woff2"),url(*) format("woff")}@font-face{font-display:var(--fontsource-display,swap);font-family:Poppins;font-style:normal;font-weight:400;src:url(*) format("woff2"),url(*) format("woff")}@font-face{font-display:var(--fontsource-display,swap);font-family:Poppins;font-style:normal;font-weight:500;src:url(*) format("woff2"),url(*) format("woff")}@font-face{font-display:var(--fontsource-display,swap);font-family:Poppins;font-style:normal;font-weight:600;src:url(*) format("woff2"),url(*) format("woff")}@font-face{font-display:var(--fontsource-display,swap);font-family:Poppins;font-style:normal;font-weight:700;src:url(*) format("woff2"),url(*) format("woff")}@font-face{font-display:var(--fontsource-display,swap);font-family:Poppins;font-style:normal;font-weight:800;src:url(*) format("woff2"),url(*) format("woff")}@font-face{font-display:var(--fontsource-display,swap);font-family:Poppins;font-style:normal;font-weight:900;src:url(*) format("woff2"),url(*) format("woff")}'
+process.chdir(__dirname + '/..')
+
+t.test('does not oom on long glob', async t => {
+  var g = new Glob(pattern, {})
+  const results = await g.walk()
+
+  t.equal(
+    results.length,
+    0,
+    'must match all files'
+  )
+})
+


### PR DESCRIPTION
I was running into an out-of-memory problem with one of our tools and traced it back to node-glob.

The problem arises when the glob is extremely complex or potentially invalid. I know this is pretty heavy edge case and the glob in the test is CSS and not a glob :) but I was wondering if there is something that can be done about this and if the test might help to debug this.

This also only really happens if the folder where the glob is executed against is big. That is why I set it to the repo root in the test.

Side note: fast-glob handles this without a problem and super fast. (obviously does not match anything) 