### PR TITLE
fix(types): re-export some stuff from path-scurry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,14 @@ export type {
 export { hasMagic } from './has-magic.js'
 export type { IgnoreLike } from './ignore.js'
 export type { MatchStream } from './walker.js'
+export type {
+  Path,
+  WalkOptionsWithFileTypesTrue,
+  WalkOptionsWithFileTypesUnset,
+  WalkOptions,
+  FSOption,
+} from 'path-scurry'
+
 /* c8 ignore stop */
 
 export const glob = Object.assign(glob_, {


### PR DESCRIPTION
This re-exports types that are accessible via the `Path` objects sometimes returned by `glob`.

Types within `path-scurry` consumed only by members tagged `@internal` are not re-exported.

* * *

Closes #551.

So, I didn't want to re-export _everything_, because a) you have to be explicit about what to re-export in TypeScript v4.9.5 using the `export type from` syntax, so I couldn't get away with it easily, and b) some portion of the exports from `path-scurry` look like they're only needed for consumers writing subclasses that extend `PathBase`.