### PR TITLE
fix: use `node:`-prefixed requires for builtins

### DIFF
--- a/src/glob.ts
+++ b/src/glob.ts
@@ -8,7 +8,7 @@ import {
   PathScurryPosix,
   PathScurryWin32,
 } from 'path-scurry'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import { IgnoreLike } from './ignore.js'
 import { Pattern } from './pattern.js'
 import { GlobStream, GlobWalker } from './walker.js'


### PR DESCRIPTION
Fixes and closes isaacs/node-glob#580 by switching to `node:`- prefixed requires for Node API builtins.

Will need releases for `minipass` and `path-scurry`, PRs for these are noted below.

**Related issues:**
- isaacs/path-scurry#16
- isaacs/minipass#54

**Peer PRs:**
- isaacs/path-scurry#17
- isaacs/minipass#55
