### PR TITLE
fix: benchmark ESM build compatibility

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -109,14 +109,14 @@ MJS
 
   echo -n $'node current globSync mjs    \t'
   cat > "$wd/bench-working-dir/sync.mjs" <<MJS
-  import {globSync} from '$wd/dist/mjs/index.js'
+  import {globSync} from '$wd/dist/esm/index.js'
   console.log(globSync(process.argv[2]).length)
 MJS
   t node "$wd/bench-working-dir/sync.mjs" "$p"
 
   echo -n $'node current glob syncStream  \t'
   cat > "$wd/bench-working-dir/stream-sync.mjs" <<MJS
-  import {globStreamSync} from '$wd/dist/mjs/index.js'
+  import {globStreamSync} from '$wd/dist/esm/index.js'
   let c = 0
   globStreamSync(process.argv[2])
     .on('data', () => c++)
@@ -153,14 +153,14 @@ MJS
 
   echo -n $'node current glob async mjs   \t'
   cat > "$wd/bench-working-dir/async.mjs" <<MJS
-  import { glob } from '$wd/dist/mjs/index.js'
+  import { glob } from '$wd/dist/esm/index.js'
   glob(process.argv[2]).then(files => console.log(files.length))
 MJS
   t node "$wd/bench-working-dir/async.mjs" "$p"
 
   echo -n $'node current glob stream      \t'
   cat > "$wd/bench-working-dir/stream.mjs" <<MJS
-  import {globStream} from '$wd/dist/mjs/index.js'
+  import {globStream} from '$wd/dist/esm/index.js'
   let c = 0
   globStream(process.argv[2])
     .on('data', () => c++)


### PR DESCRIPTION
# 🤔 What's changed?

- Migrated the benchmark script from MJS to ESM to match [b7d7667](https://github.com/isaacs/node-glob/commit/b7d7667df0698b0e2c5589319b2b9b801eae35c0) and enable it to run

<details>
<summary>Present module not found error</summary>
@kieran-ryan ➜ /workspaces/node-glob (main) $ npm run bench

> glob@10.3.15 prebench
> npm run prepare


> glob@10.3.15 prepare
> tshy


> glob@10.3.15 bench
> bash benchmark.sh

Making benchmark fixtures

--- pattern: '{0000,0,1111,1}/{0000,0,1111,1}/{0000,0,1111,1}/**' ---
~~ sync ~~
node fast-glob sync             0m0.091s  1600
node globby sync                0m0.118s  1600
node current globSync mjs       node:internal/modules/esm/resolve:265
    throw new ERR_MODULE_NOT_FOUND(
          ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspaces/node-glob/dist/mjs/index.js' imported from /workspaces/node-glob/bench-working-dir/sync.mjs
    at finalizeResolution (node:internal/modules/esm/resolve:265:11)
    at moduleResolve (node:internal/modules/esm/resolve:933:10)
    at defaultResolve (node:internal/modules/esm/resolve:1157:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:390:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:359:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:234:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:87:39)
    at link (node:internal/modules/esm/module_job:86:36) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///workspaces/node-glob/dist/mjs/index.js'
}

Node.js v20.12.1

real    0m0.033s
user    0m0.028s
sys     0m0.004s
</details>

# 🏷️ What kind of change is this?

- 🐛 Bug fix (non-breaking change which fixes a defect)