### PR TITLE
Add 14.latest and 16.latest back to v10 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 21.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 21.x]
         platform:
         - os: ubuntu-latest
           shell: bash


### PR DESCRIPTION
👋🏼 Thanks for `glob`. I don't have an issue, but want to suggest adding 14.latest back to the CI to prevent an issue in the future.

https://github.com/isaacs/node-glob/commit/d06c8f8c8288c89a4892f4ebcc23ca21840aa4a1 added back support for 14.latest and 16.latest, but they weren't added back to the CI.

I know `engines` was removed in 10.4.5, but I'm guessing the intent is for v10 to always support 14.latest and above?